### PR TITLE
[JENKINS-29894] Allow to specify includesPatternFile

### DIFF
--- a/demo/JENKINS_HOME/jobs/flow/config.xml
+++ b/demo/JENKINS_HOME/jobs/flow/config.xml
@@ -9,15 +9,16 @@
   git url: 'https://github.com/jenkinsci/parallel-test-executor-plugin-sample'
   archive 'pom.xml, src/'
 }
-def splits = splitTests([$class: 'CountDrivenParallelism', size: 5])
+def splits = splitTests(parallelism: [$class: 'CountDrivenParallelism', size: 5], generateInclusions: true)
 def branches = [:]
 for (int i = 0; i &lt; splits.size(); i++) {
-  def exclusions = splits.get(i);
+  def split = splits.get(i);
   branches["split${i}"] = {
     node('standard') {
       sh 'rm -rf *'
       unarchive mapping: ['pom.xml' : '.', 'src/' : '.']
-      writeFile file: 'exclusions.txt', text: exclusions.join("\n")
+      writeFile file: (split.includes ? 'inclusions.txt' : 'exclusions.txt'), text: split.list.join("\n")
+      writeFile file: (split.includes ? 'exclusions.txt' : 'inclusions.txt'), text: ''
       sh 'mvn -B clean test -Dmaven.test.failure.ignore'
       step([$class: 'JUnitResultArchiver', testResults: 'target/surefire-reports/*.xml'])
     }

--- a/demo/JENKINS_HOME/jobs/main/config.xml
+++ b/demo/JENKINS_HOME/jobs/main/config.xml
@@ -17,6 +17,7 @@
         <size>5</size>
       </parallelism>
       <testJob>sub</testJob>
+      <includesPatternFile>inclusions.txt</includesPatternFile>
       <patternFile>exclusions.txt</patternFile>
       <testReportFiles>**/target/surefire-reports/</testReportFiles>
       <doNotArchiveTestResults>false</doNotArchiveTestResults>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,11 @@
       <version>1.2</version>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>1.9.5</version>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
       <version>${workflow.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,12 @@
       <artifactId>workflow-step-api</artifactId>
       <version>${workflow.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>script-security</artifactId>
+      <version>1.13</version>
+      <optional>true</optional>
+    </dependency>
     <dependency> <!-- For ease of demonstrating parallel-test-executor-plugin-sample -->
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>

--- a/src/main/java/org/jenkinsci/plugins/parallel_test_executor/InclusionExclusionPattern.java
+++ b/src/main/java/org/jenkinsci/plugins/parallel_test_executor/InclusionExclusionPattern.java
@@ -1,0 +1,25 @@
+package org.jenkinsci.plugins.parallel_test_executor;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author Vincent Latombe <vincent@latombe.net>
+ */
+public class InclusionExclusionPattern {
+    public boolean isIncludes() {
+        return includes;
+    }
+
+    public List<String> getList() {
+        return Collections.unmodifiableList(list);
+    }
+
+    private final boolean includes;
+    private final List<String> list;
+
+    InclusionExclusionPattern(List<String> list, boolean includes) {
+        this.list = list;
+        this.includes = includes;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/parallel_test_executor/InclusionExclusionPattern.java
+++ b/src/main/java/org/jenkinsci/plugins/parallel_test_executor/InclusionExclusionPattern.java
@@ -4,7 +4,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * @author Vincent Latombe <vincent@latombe.net>
+ * A list of file name patterns to include or exclude
  */
 public class InclusionExclusionPattern {
     public boolean isIncludes() {
@@ -18,7 +18,7 @@ public class InclusionExclusionPattern {
     private final boolean includes;
     private final List<String> list;
 
-    InclusionExclusionPattern(List<String> list, boolean includes) {
+    public InclusionExclusionPattern(List<String> list, boolean includes) {
         this.list = list;
         this.includes = includes;
     }

--- a/src/main/java/org/jenkinsci/plugins/parallel_test_executor/InclusionExclusionPattern.java
+++ b/src/main/java/org/jenkinsci/plugins/parallel_test_executor/InclusionExclusionPattern.java
@@ -1,16 +1,21 @@
 package org.jenkinsci.plugins.parallel_test_executor;
 
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
+
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
 
 /**
  * A list of file name patterns to include or exclude
  */
-public class InclusionExclusionPattern {
+public class InclusionExclusionPattern implements Serializable {
+    @Whitelisted
     public boolean isIncludes() {
         return includes;
     }
 
+    @Whitelisted
     public List<String> getList() {
         return Collections.unmodifiableList(list);
     }
@@ -21,5 +26,13 @@ public class InclusionExclusionPattern {
     public InclusionExclusionPattern(List<String> list, boolean includes) {
         this.list = list;
         this.includes = includes;
+    }
+
+    @Override
+    public String toString() {
+        return "InclusionExclusionPattern{" +
+                "includes=" + includes +
+                ", list=" + list +
+                '}';
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/parallel_test_executor/MultipleBinaryFileParameterFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/parallel_test_executor/MultipleBinaryFileParameterFactory.java
@@ -1,0 +1,119 @@
+package org.jenkinsci.plugins.parallel_test_executor;
+
+import com.google.common.collect.Lists;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.model.AbstractBuild;
+import hudson.model.Action;
+import hudson.model.FileParameterValue;
+import hudson.model.ParametersAction;
+import hudson.model.TaskListener;
+import hudson.plugins.parameterizedtrigger.AbstractBuildParameterFactory;
+import hudson.plugins.parameterizedtrigger.AbstractBuildParameterFactoryDescriptor;
+import hudson.plugins.parameterizedtrigger.AbstractBuildParameters;
+import hudson.plugins.parameterizedtrigger.FileBuildParameterFactory;
+import hudson.util.IOException2;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.logging.Logger;
+
+/**
+ * Essentially a copy-paste of {@link hudson.plugins.parameterizedtrigger.BinaryFileParameterFactory} that takes a
+ * list of mappings "name -> filePattern" to generate parameters.
+ *
+ * @author Vincent Latombe <vincent@latombe.net>
+ */
+public class MultipleBinaryFileParameterFactory extends AbstractBuildParameterFactory {
+    public static class Tuple {
+        public Tuple(String parameterName, String filePattern) {
+            this.parameterName = parameterName;
+            this.filePattern = filePattern;
+        }
+        public final String parameterName;
+        public final String filePattern;
+    }
+
+    private final List<Tuple> parametersList;
+    private final FileBuildParameterFactory.NoFilesFoundEnum noFilesFoundAction;
+
+    @DataBoundConstructor
+    public MultipleBinaryFileParameterFactory(List<Tuple> parametersList, FileBuildParameterFactory.NoFilesFoundEnum noFilesFoundAction) {
+        this.parametersList = parametersList;
+        this.noFilesFoundAction = noFilesFoundAction;
+    }
+
+    public MultipleBinaryFileParameterFactory(List<Tuple> parametersList) {
+        this(parametersList, FileBuildParameterFactory.NoFilesFoundEnum.SKIP);
+    }
+
+    public FileBuildParameterFactory.NoFilesFoundEnum getNoFilesFoundAction() {
+        return noFilesFoundAction;
+    }
+
+    @Override
+    public List<AbstractBuildParameters> getParameters(AbstractBuild<?, ?> build, TaskListener listener) throws IOException, InterruptedException, AbstractBuildParameters.DontTriggerException {
+        List<AbstractBuildParameters> result = Lists.newArrayList();
+        int totalFiles = 0;
+        for (final Tuple t : parametersList) {
+            // save them into the master because FileParameterValue might need files after the slave workspace have disappeared/reused
+            FilePath target = new FilePath(build.getRootDir()).child("parameter-files");
+                int k = build.getWorkspace().copyRecursiveTo(t.filePattern, target);
+                totalFiles += k;
+                if (k > 0) {
+                    for (final FilePath f : target.list(t.filePattern)) {
+                        LOGGER.fine("Triggering build with " + f.getName());
+
+                        result.add(new AbstractBuildParameters() {
+                            @Override
+                            public Action getAction(AbstractBuild<?, ?> build, TaskListener listener) throws IOException, InterruptedException, DontTriggerException {
+                                assert f.getChannel() == null;    // we copied files locally. This file must be local to the master
+                                FileParameterValue fv = new FileParameterValue(t.parameterName, new File(f.getRemote()), f.getName());
+                                if ($setLocation != null) {
+                                    try {
+                                        $setLocation.invoke(fv, t.parameterName);
+                                    } catch (IllegalAccessException e) {
+                                        // be defensive as the core might change
+                                    } catch (InvocationTargetException e) {
+                                        // be defensive as the core might change
+                                    }
+                                }
+                                return new ParametersAction(fv);
+                            }
+                        });
+                    }
+                }
+        }
+        if (totalFiles ==0) {
+            noFilesFoundAction.failCheck(listener);
+        }
+
+        return result;
+    }
+
+
+    @Extension
+    public static class DescriptorImpl extends AbstractBuildParameterFactoryDescriptor {
+        @Override
+        public String getDisplayName() {
+            return "Multiple Binary Files (not meant to be used)";
+        }
+    }
+
+    private static Method $setLocation;
+
+    static {
+        // work around NPE fixed in the core at 4a95cc6f9269108e607077dc9fd57f06e4c9af26
+        try {
+            $setLocation = FileParameterValue.class.getDeclaredMethod("setLocation",String.class);
+            $setLocation.setAccessible(true);
+        } catch (NoSuchMethodException e) {
+            // ignore
+        }
+    }
+    private static final Logger LOGGER = Logger.getLogger(MultipleBinaryFileParameterFactory.class.getName());
+}

--- a/src/main/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutor.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableSet;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
+import hudson.Util;
 import hudson.model.*;
 import hudson.plugins.parameterizedtrigger.*;
 import hudson.tasks.BuildStepDescriptor;
@@ -17,7 +18,6 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
-import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
@@ -36,18 +36,20 @@ public class ParallelTestExecutor extends Builder {
 
     private String testJob;
     private String patternFile;
+    private String includesPatternFile;
     private String testReportFiles;
     private boolean doNotArchiveTestResults = false;
     private List<AbstractBuildParameters> parameters;
 
     @DataBoundConstructor
-    public ParallelTestExecutor(Parallelism parallelism, String testJob, String patternFile, String testReportFiles, boolean archiveTestResults, List<AbstractBuildParameters> parameters) {
+    public ParallelTestExecutor(Parallelism parallelism, String testJob, String patternFile, String testReportFiles, boolean archiveTestResults, List<AbstractBuildParameters> parameters, String includesPatternFile) {
         this.parallelism = parallelism;
         this.testJob = testJob;
         this.patternFile = patternFile;
         this.testReportFiles = testReportFiles;
         this.parameters = parameters;
         this.doNotArchiveTestResults = !archiveTestResults;
+        this.includesPatternFile = Util.fixEmpty(includesPatternFile);
     }
 
     public Parallelism getParallelism() {
@@ -60,6 +62,10 @@ public class ParallelTestExecutor extends Builder {
 
     public String getPatternFile() {
         return patternFile;
+    }
+
+    public String getIncludesPatternFile() {
+        return includesPatternFile;
     }
 
     public String getTestReportFiles() {
@@ -101,13 +107,14 @@ public class ParallelTestExecutor extends Builder {
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
         FilePath dir = build.getWorkspace().child("test-splits");
         dir.deleteRecursive();
-        List<List<String>> splits = findTestSplits(parallelism, build, listener);
+        List<InclusionExclusionPattern> splits = findTestSplits(parallelism, build, listener, includesPatternFile != null);
         for (int i = 0; i < splits.size(); i++) {
-            OutputStream os = dir.child("split." + i + ".txt").write();
+            InclusionExclusionPattern pattern = splits.get(i);
+            OutputStream os = dir.child("split." + i + "." + (pattern.includes ? "include" : "exclude") + ".txt").write();
             try {
                 PrintWriter pw = new PrintWriter(new OutputStreamWriter(os, Charsets.UTF_8));
-                for (String exclusion : splits.get(i)) {
-                    pw.println(exclusion);
+                for (String filePattern : pattern.list) {
+                    pw.println(filePattern);
                 }
                 pw.close();
             } finally {
@@ -124,11 +131,11 @@ public class ParallelTestExecutor extends Builder {
         return true;
     }
 
-    static List<List<String>> findTestSplits(Parallelism parallelism, Run<?,?> build, TaskListener listener) {
+    static List<InclusionExclusionPattern> findTestSplits(Parallelism parallelism, Run<?,?> build, TaskListener listener, boolean generateInclusions) {
         TestResult tr = findPreviousTestResult(build, listener);
         if (tr == null) {
             listener.getLogger().println("No record available, so executing everything in one place");
-            return Collections.singletonList(Collections.<String>emptyList());
+            return Collections.singletonList(new InclusionExclusionPattern(Collections.<String>emptyList(), false));
         } else {
 
             Map<String/*fully qualified class name*/, TestClass> data = new HashMap<String, TestClass>();
@@ -173,18 +180,30 @@ public class ParallelTestExecutor extends Builder {
             listener.getLogger().printf("%d test classes (%dms) divided into %d sets. Min=%dms, Average=%dms, Max=%dms, stddev=%dms\n",
                     data.size(), total, n, min, average, max, stddev);
 
-            List<List<String>> r = new ArrayList<List<String>>();
+            List<InclusionExclusionPattern> r = new ArrayList<InclusionExclusionPattern>();
             for (int i = 0; i < n; i++) {
                 Knapsack k = knapsacks.get(i);
-                List<String> exclusions = new ArrayList<String>();
-                r.add(exclusions);
+                boolean shouldIncludeElements = generateInclusions && i != 0;
+                List<String> elements = new ArrayList<String>();
+                r.add(new InclusionExclusionPattern(elements, shouldIncludeElements));
                 for (TestClass d : sorted) {
-                    if (d.knapsack == k) continue;
-                    exclusions.add(d.getSourceFileName(".java"));
-                    exclusions.add(d.getSourceFileName(".class"));
+                    if (shouldIncludeElements == (d.knapsack == k)) {
+                        elements.add(d.getSourceFileName(".java"));
+                        elements.add(d.getSourceFileName(".class"));
+                    }
                 }
             }
             return r;
+        }
+    }
+
+    static class InclusionExclusionPattern {
+        boolean includes;
+        List<String> list;
+
+        InclusionExclusionPattern(List<String> list, boolean includes) {
+            this.list = list;
+            this.includes = includes;
         }
     }
 
@@ -218,11 +237,16 @@ public class ParallelTestExecutor extends Builder {
         }
 
         // actual logic of child process triggering is left up to the parameterized build
+        List<MultipleBinaryFileParameterFactory.Tuple> tuples = new ArrayList<MultipleBinaryFileParameterFactory.Tuple>();
+        tuples.add(new MultipleBinaryFileParameterFactory.Tuple(getPatternFile(), "test-splits/split.*.exclude.txt"));
+        if (includesPatternFile != null) {
+            tuples.add(new MultipleBinaryFileParameterFactory.Tuple(getIncludesPatternFile(), "test-splits/split.*.include.txt"));
+        }
+        MultipleBinaryFileParameterFactory factory = new MultipleBinaryFileParameterFactory(tuples);
         BlockableBuildTriggerConfig config = new BlockableBuildTriggerConfig(
                 testJob,
                 blocking,
-                Collections.<AbstractBuildParameterFactory>singletonList(
-                        new BinaryFileParameterFactory(getPatternFile(), "test-splits/split.*.txt")),
+                Collections.<AbstractBuildParameterFactory>singletonList(factory),
                 parameterList
         );
 

--- a/src/main/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutor.java
@@ -110,10 +110,10 @@ public class ParallelTestExecutor extends Builder {
         List<InclusionExclusionPattern> splits = findTestSplits(parallelism, build, listener, includesPatternFile != null);
         for (int i = 0; i < splits.size(); i++) {
             InclusionExclusionPattern pattern = splits.get(i);
-            OutputStream os = dir.child("split." + i + "." + (pattern.includes ? "include" : "exclude") + ".txt").write();
+            OutputStream os = dir.child("split." + i + "." + (pattern.isIncludes() ? "include" : "exclude") + ".txt").write();
             try {
                 PrintWriter pw = new PrintWriter(new OutputStreamWriter(os, Charsets.UTF_8));
-                for (String filePattern : pattern.list) {
+                for (String filePattern : pattern.getList()) {
                     pw.println(filePattern);
                 }
                 pw.close();
@@ -194,16 +194,6 @@ public class ParallelTestExecutor extends Builder {
                 }
             }
             return r;
-        }
-    }
-
-    static class InclusionExclusionPattern {
-        boolean includes;
-        List<String> list;
-
-        InclusionExclusionPattern(List<String> list, boolean includes) {
-            this.list = list;
-            this.includes = includes;
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/parallel_test_executor/SplitStep.java
+++ b/src/main/java/org/jenkinsci/plugins/parallel_test_executor/SplitStep.java
@@ -42,14 +42,14 @@ public final class SplitStep extends AbstractStepImpl {
 
     }
 
-    public static final class Execution extends AbstractSynchronousStepExecution<List<List<String>>> {
+    public static final class Execution extends AbstractSynchronousStepExecution<List<InclusionExclusionPattern>> {
 
         @Inject private SplitStep step;
         @StepContextParameter private Run<?,?> build;
         @StepContextParameter private TaskListener listener;
 
-        @Override protected List<List<String>> run() throws Exception {
-            return ParallelTestExecutor.findTestSplits(step.parallelism, build, listener);
+        @Override protected List<InclusionExclusionPattern> run() throws Exception {
+            return ParallelTestExecutor.findTestSplits(step.parallelism, build, listener, false);
         }
 
     }

--- a/src/main/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutor/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutor/config.groovy
@@ -11,6 +11,9 @@ f.entry(title:"Test job to run", field:"testJob") {
 f.entry(title:"Exclusion file name in the test job", field:"patternFile") {
     f.textbox()
 }
+f.entry(title:"Optional inclusion file name in the test job", field:"includesPatternFile") {
+    f.textbox()
+}
 f.entry(title:"Degree of parallelism", field:"parallelism") {
     f.hetero_radio(field:"parallelism", descriptors:Jenkins.instance.getDescriptorList(Parallelism.class))
 }

--- a/src/main/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutor/help-includesPatternFile.html
+++ b/src/main/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutor/help-includesPatternFile.html
@@ -1,0 +1,7 @@
+<div>
+    A text file that lists one Java source file name per line gets created by this path inside
+    the workspace of the test job.
+    The path is relative to the workspace of the test job.
+    Your test job must honor this inclusion list while executing tests.
+    See the help of this builder for more details.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutor/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutor/help.html
@@ -10,7 +10,14 @@
     and the test job is triggered for each unit, with the exclusion file placed inside the workspace at your specified location.
 
     <p>
-    You are responsible for configuring the build script in the test job to honor the exclusion file.
+    Optionally, if your test job supports it, you may provide a test-inclusion file name. If defined, the plugin will
+    generate inclusion lists for all parallel units but one which will still use exclusion list. This avoids new test
+    cases from being included in all units on their first run. If you don't use an inclusion file, when a new test is
+    added, the first build afterward will be executed in all the sub-builds,
+    because it's not in the exclusion list on any of the units.
+
+    <p>
+    You are responsible for configuring the build script in the test job to honor the exclusion and inclusion file.
     A standard technique is to write the build script to always refer to a fixed exclusion list file,
     and check in an empty file by that name to your SCM. You can then specify that file as the "exclusion file name"
     in the configuration of this builder, and the builder will overwrite the empty file from SCM
@@ -23,9 +30,4 @@
     <p>
     At the end of the executions of the test job, the specified report directories are brought back into
     this job's workspace, then the standard JUnit test report collector will tally them.
-
-    <p>
-    We use an exclusion list as opposed to an inclusion list so that newly added tests can be accounted for.
-    A related gotcha is that if a new test is added, the first build afterward will be executed in all the sub-builds,
-    because it's not in the exclusion list on any of the units.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/parallel_test_executor/SplitStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/parallel_test_executor/SplitStep/config.jelly
@@ -4,4 +4,7 @@
     <f:entry field="parallelism">
         <f:dropdownDescriptorSelector field="parallelism" title="Degree of parallelism"/>
     </f:entry>
+    <f:entry field="generateInclusions">
+        <f:checkbox title="Generate inclusion patterns"/>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/parallel_test_executor/SplitStep/help-generateInclusions.html
+++ b/src/main/resources/org/jenkinsci/plugins/parallel_test_executor/SplitStep/help-generateInclusions.html
@@ -1,0 +1,9 @@
+<p>If disabled, the splitStep call will return a <i>List&lt;List&lt;String&gt;&gt;</i> containing the exclusion patterns for the different buckets.</p>
+
+<p>If enabled, the splitStep call won't return a <i>List&lt;List&lt;String&gt;&gt;</i>.<br/>
+Instead it will return a <i>List</i> of a structure with :
+<ul>
+    <li><i>boolean includes</i> whether the following list is an inclusion or an exclusion list</li>
+    <li><i>List&lt;String&gt; list</i> the list of patterns</li>
+</ul>
+</p>

--- a/src/test/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest.java
+++ b/src/test/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest.java
@@ -1,0 +1,114 @@
+package org.jenkinsci.plugins.parallel_test_executor;
+
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.tasks.junit.TestResult;
+import hudson.tasks.test.AbstractTestResultAction;
+import org.apache.tools.ant.DirectoryScanner;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ParallelTestExecutorUnitTest {
+
+    ParallelTestExecutor instance;
+
+    @Mock Run<?, ?> build;
+
+    @Mock Run<?, ?> previousBuild;
+
+    @Mock TaskListener listener;
+
+    @Mock AbstractTestResultAction action;
+
+    @Rule public TestName name = new TestName();
+
+    File projectRootDir;
+
+    DirectoryScanner scanner;
+
+
+    @Before
+    public void setUp() throws Exception {
+        when(build.getPreviousBuild()).thenReturn((Run)previousBuild);
+        when(previousBuild.getResult()).thenReturn(Result.SUCCESS);
+        when(listener.getLogger()).thenReturn(System.err);
+        when(previousBuild.getAction(eq(AbstractTestResultAction.class))).thenReturn(action);
+    }
+
+    @Before
+    public void findProjectRoot() throws Exception {
+        URL url = getClass().getResource(getClass().getSimpleName() + "/" + this.name.getMethodName());
+        assumeThat("The test resource for " + this.name.getMethodName() + " exist", url, Matchers.notNullValue());
+        try {
+            projectRootDir = new File(url.toURI());
+        } catch (URISyntaxException e) {
+            projectRootDir = new File(url.getPath());
+        }
+        scanner = new DirectoryScanner();
+        scanner.setBasedir(projectRootDir);
+        scanner.scan();
+    }
+
+    @Test
+    public void findTestSplits() throws Exception {
+        TestResult testResult = new TestResult(0L, scanner, false);
+        testResult.tally();
+        when(action.getResult()).thenReturn(testResult);
+
+        CountDrivenParallelism parallelism = new CountDrivenParallelism(5);
+        List<InclusionExclusionPattern> splits = ParallelTestExecutor.findTestSplits(parallelism, build, listener, false);
+        assertEquals(5, splits.size());
+        for (InclusionExclusionPattern split : splits) {
+            assertFalse(split.isIncludes());
+        }
+    }
+
+    @Test
+    public void findTestSplitsInclusions() throws Exception {
+        TestResult testResult = new TestResult(0L, scanner, false);
+        testResult.tally();
+        when(action.getResult()).thenReturn(testResult);
+
+        CountDrivenParallelism parallelism = new CountDrivenParallelism(5);
+        List<InclusionExclusionPattern> splits = ParallelTestExecutor.findTestSplits(parallelism, build, listener, true);
+        assertEquals(5, splits.size());
+        List<String> exclusions = new ArrayList<String>(splits.get(0).getList());
+        List<String> inclusions = new ArrayList<String>();
+        for (int i = 0; i < splits.size(); i++) {
+            InclusionExclusionPattern split = splits.get(i);
+            assertEquals(i != 0, split.isIncludes());
+            if (split.isIncludes()) {
+                inclusions.addAll(split.getList());
+            }
+        }
+        Collections.sort(exclusions);
+        Collections.sort(inclusions);
+        assertEquals("exclusions set should contain all elements included by inclusions set", inclusions, exclusions);
+    }
+}

--- a/src/test/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest/findTestSplits/report-Test1.xml
+++ b/src/test/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest/findTestSplits/report-Test1.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="org.jenkinsci.plugins.parallel_test_executor.Test1" time="110.00" tests="20" errors="0" skipped="0" failures="0">
+  <testcase name="test1Case1" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="1.00"/>
+  <testcase name="test1Case2" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="2.00"/>
+  <testcase name="test1Case3" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="3.00"/>
+  <testcase name="test1Case4" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="4.00"/>
+  <testcase name="test1Case5" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="5.00"/>
+  <testcase name="test1Case6" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="6.00"/>
+  <testcase name="test1Case7" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="7.00"/>
+  <testcase name="test1Case8" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="8.00"/>
+  <testcase name="test1Case9" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="9.00"/>
+  <testcase name="test1Case10" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="10.00"/>
+  <testcase name="test1Case11" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="1.00"/>
+  <testcase name="test1Case12" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="2.00"/>
+  <testcase name="test1Case13" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="3.00"/>
+  <testcase name="test1Case14" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="4.00"/>
+  <testcase name="test1Case15" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="5.00"/>
+  <testcase name="test1Case16" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="6.00"/>
+  <testcase name="test1Case17" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="7.00"/>
+  <testcase name="test1Case18" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="8.00"/>
+  <testcase name="test1Case19" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="9.00"/>
+  <testcase name="test1Case20" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="10.22"/>
+</testsuite>

--- a/src/test/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest/findTestSplits/report-Test2.xml
+++ b/src/test/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest/findTestSplits/report-Test2.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="org.jenkinsci.plugins.parallel_test_executor.Test2" time="110.00" tests="20" errors="0" skipped="0" failures="0">
+  <testcase name="test2Case1" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="1.00"/>
+  <testcase name="test2Case2" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="2.00"/>
+  <testcase name="test2Case3" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="3.00"/>
+  <testcase name="test2Case4" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="4.00"/>
+  <testcase name="test2Case5" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="5.00"/>
+  <testcase name="test2Case6" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="6.00"/>
+  <testcase name="test2Case7" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="7.00"/>
+  <testcase name="test2Case8" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="8.00"/>
+  <testcase name="test2Case9" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="9.00"/>
+  <testcase name="test2Case10" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="10.00"/>
+  <testcase name="test2Case11" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="1.00"/>
+  <testcase name="test2Case12" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="2.00"/>
+  <testcase name="test2Case13" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="3.00"/>
+  <testcase name="test2Case14" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="4.00"/>
+  <testcase name="test2Case15" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="5.00"/>
+  <testcase name="test2Case16" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="6.00"/>
+  <testcase name="test2Case17" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="7.00"/>
+  <testcase name="test2Case18" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="8.00"/>
+  <testcase name="test2Case19" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="9.00"/>
+  <testcase name="test2Case20" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="10.22"/>
+</testsuite>

--- a/src/test/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest/findTestSplits/report-Test3.xml
+++ b/src/test/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest/findTestSplits/report-Test3.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="org.jenkinsci.plugins.parallel_test_executor.Test3" time="110.00" tests="20" errors="0" skipped="0" failures="0">
+  <testcase name="test3Case1" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="1.00"/>
+  <testcase name="test3Case2" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="2.00"/>
+  <testcase name="test3Case3" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="3.00"/>
+  <testcase name="test3Case4" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="4.00"/>
+  <testcase name="test3Case5" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="5.00"/>
+  <testcase name="test3Case6" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="6.00"/>
+  <testcase name="test3Case7" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="7.00"/>
+  <testcase name="test3Case8" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="8.00"/>
+  <testcase name="test3Case9" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="9.00"/>
+  <testcase name="test3Case10" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="10.00"/>
+  <testcase name="test3Case11" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="1.00"/>
+  <testcase name="test3Case12" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="2.00"/>
+  <testcase name="test3Case13" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="3.00"/>
+  <testcase name="test3Case14" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="4.00"/>
+  <testcase name="test3Case15" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="5.00"/>
+  <testcase name="test3Case16" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="6.00"/>
+  <testcase name="test3Case17" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="7.00"/>
+  <testcase name="test3Case18" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="8.00"/>
+  <testcase name="test3Case19" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="9.00"/>
+  <testcase name="test3Case20" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="10.22"/>
+</testsuite>

--- a/src/test/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest/findTestSplits/report-Test4.xml
+++ b/src/test/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest/findTestSplits/report-Test4.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="org.jenkinsci.plugins.parallel_test_executor.Test4" time="110.00" tests="20" errors="0" skipped="0" failures="0">
+  <testcase name="test4Case1" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="1.00"/>
+  <testcase name="test4Case2" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="2.00"/>
+  <testcase name="test4Case3" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="3.00"/>
+  <testcase name="test4Case4" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="4.00"/>
+  <testcase name="test4Case5" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="5.00"/>
+  <testcase name="test4Case6" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="6.00"/>
+  <testcase name="test4Case7" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="7.00"/>
+  <testcase name="test4Case8" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="8.00"/>
+  <testcase name="test4Case9" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="9.00"/>
+  <testcase name="test4Case10" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="10.00"/>
+  <testcase name="test4Case11" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="1.00"/>
+  <testcase name="test4Case12" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="2.00"/>
+  <testcase name="test4Case13" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="3.00"/>
+  <testcase name="test4Case14" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="4.00"/>
+  <testcase name="test4Case15" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="5.00"/>
+  <testcase name="test4Case16" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="6.00"/>
+  <testcase name="test4Case17" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="7.00"/>
+  <testcase name="test4Case18" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="8.00"/>
+  <testcase name="test4Case19" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="9.00"/>
+  <testcase name="test4Case20" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="10.22"/>
+</testsuite>

--- a/src/test/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest/findTestSplits/report-Test5.xml
+++ b/src/test/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest/findTestSplits/report-Test5.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="org.jenkinsci.plugins.parallel_test_executor.Test5" time="110.00" tests="20" errors="0" skipped="0" failures="0">
+  <testcase name="test5Case1" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="1.00"/>
+  <testcase name="test5Case2" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="2.00"/>
+  <testcase name="test5Case3" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="3.00"/>
+  <testcase name="test5Case4" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="4.00"/>
+  <testcase name="test5Case5" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="5.00"/>
+  <testcase name="test5Case6" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="6.00"/>
+  <testcase name="test5Case7" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="7.00"/>
+  <testcase name="test5Case8" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="8.00"/>
+  <testcase name="test5Case9" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="9.00"/>
+  <testcase name="test5Case10" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="10.00"/>
+  <testcase name="test5Case11" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="1.00"/>
+  <testcase name="test5Case12" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="2.00"/>
+  <testcase name="test5Case13" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="3.00"/>
+  <testcase name="test5Case14" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="4.00"/>
+  <testcase name="test5Case15" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="5.00"/>
+  <testcase name="test5Case16" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="6.00"/>
+  <testcase name="test5Case17" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="7.00"/>
+  <testcase name="test5Case18" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="8.00"/>
+  <testcase name="test5Case19" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="9.00"/>
+  <testcase name="test5Case20" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="10.22"/>
+</testsuite>

--- a/src/test/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest/findTestSplitsInclusions/report-Test1.xml
+++ b/src/test/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest/findTestSplitsInclusions/report-Test1.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="org.jenkinsci.plugins.parallel_test_executor.Test1" time="110.00" tests="20" errors="0" skipped="0" failures="0">
+  <testcase name="test1Case1" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="1.00"/>
+  <testcase name="test1Case2" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="2.00"/>
+  <testcase name="test1Case3" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="3.00"/>
+  <testcase name="test1Case4" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="4.00"/>
+  <testcase name="test1Case5" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="5.00"/>
+  <testcase name="test1Case6" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="6.00"/>
+  <testcase name="test1Case7" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="7.00"/>
+  <testcase name="test1Case8" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="8.00"/>
+  <testcase name="test1Case9" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="9.00"/>
+  <testcase name="test1Case10" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="10.00"/>
+  <testcase name="test1Case11" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="1.00"/>
+  <testcase name="test1Case12" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="2.00"/>
+  <testcase name="test1Case13" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="3.00"/>
+  <testcase name="test1Case14" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="4.00"/>
+  <testcase name="test1Case15" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="5.00"/>
+  <testcase name="test1Case16" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="6.00"/>
+  <testcase name="test1Case17" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="7.00"/>
+  <testcase name="test1Case18" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="8.00"/>
+  <testcase name="test1Case19" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="9.00"/>
+  <testcase name="test1Case20" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="10.22"/>
+</testsuite>

--- a/src/test/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest/findTestSplitsInclusions/report-Test2.xml
+++ b/src/test/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest/findTestSplitsInclusions/report-Test2.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="org.jenkinsci.plugins.parallel_test_executor.Test2" time="110.00" tests="20" errors="0" skipped="0" failures="0">
+  <testcase name="test2Case1" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="1.00"/>
+  <testcase name="test2Case2" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="2.00"/>
+  <testcase name="test2Case3" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="3.00"/>
+  <testcase name="test2Case4" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="4.00"/>
+  <testcase name="test2Case5" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="5.00"/>
+  <testcase name="test2Case6" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="6.00"/>
+  <testcase name="test2Case7" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="7.00"/>
+  <testcase name="test2Case8" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="8.00"/>
+  <testcase name="test2Case9" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="9.00"/>
+  <testcase name="test2Case10" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="10.00"/>
+  <testcase name="test2Case11" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="1.00"/>
+  <testcase name="test2Case12" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="2.00"/>
+  <testcase name="test2Case13" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="3.00"/>
+  <testcase name="test2Case14" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="4.00"/>
+  <testcase name="test2Case15" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="5.00"/>
+  <testcase name="test2Case16" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="6.00"/>
+  <testcase name="test2Case17" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="7.00"/>
+  <testcase name="test2Case18" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="8.00"/>
+  <testcase name="test2Case19" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="9.00"/>
+  <testcase name="test2Case20" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="10.22"/>
+</testsuite>

--- a/src/test/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest/findTestSplitsInclusions/report-Test3.xml
+++ b/src/test/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest/findTestSplitsInclusions/report-Test3.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="org.jenkinsci.plugins.parallel_test_executor.Test3" time="110.00" tests="20" errors="0" skipped="0" failures="0">
+  <testcase name="test3Case1" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="1.00"/>
+  <testcase name="test3Case2" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="2.00"/>
+  <testcase name="test3Case3" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="3.00"/>
+  <testcase name="test3Case4" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="4.00"/>
+  <testcase name="test3Case5" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="5.00"/>
+  <testcase name="test3Case6" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="6.00"/>
+  <testcase name="test3Case7" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="7.00"/>
+  <testcase name="test3Case8" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="8.00"/>
+  <testcase name="test3Case9" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="9.00"/>
+  <testcase name="test3Case10" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="10.00"/>
+  <testcase name="test3Case11" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="1.00"/>
+  <testcase name="test3Case12" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="2.00"/>
+  <testcase name="test3Case13" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="3.00"/>
+  <testcase name="test3Case14" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="4.00"/>
+  <testcase name="test3Case15" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="5.00"/>
+  <testcase name="test3Case16" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="6.00"/>
+  <testcase name="test3Case17" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="7.00"/>
+  <testcase name="test3Case18" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="8.00"/>
+  <testcase name="test3Case19" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="9.00"/>
+  <testcase name="test3Case20" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="10.22"/>
+</testsuite>

--- a/src/test/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest/findTestSplitsInclusions/report-Test4.xml
+++ b/src/test/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest/findTestSplitsInclusions/report-Test4.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="org.jenkinsci.plugins.parallel_test_executor.Test4" time="110.00" tests="20" errors="0" skipped="0" failures="0">
+  <testcase name="test4Case1" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="1.00"/>
+  <testcase name="test4Case2" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="2.00"/>
+  <testcase name="test4Case3" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="3.00"/>
+  <testcase name="test4Case4" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="4.00"/>
+  <testcase name="test4Case5" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="5.00"/>
+  <testcase name="test4Case6" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="6.00"/>
+  <testcase name="test4Case7" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="7.00"/>
+  <testcase name="test4Case8" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="8.00"/>
+  <testcase name="test4Case9" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="9.00"/>
+  <testcase name="test4Case10" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="10.00"/>
+  <testcase name="test4Case11" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="1.00"/>
+  <testcase name="test4Case12" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="2.00"/>
+  <testcase name="test4Case13" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="3.00"/>
+  <testcase name="test4Case14" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="4.00"/>
+  <testcase name="test4Case15" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="5.00"/>
+  <testcase name="test4Case16" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="6.00"/>
+  <testcase name="test4Case17" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="7.00"/>
+  <testcase name="test4Case18" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="8.00"/>
+  <testcase name="test4Case19" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="9.00"/>
+  <testcase name="test4Case20" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="10.22"/>
+</testsuite>

--- a/src/test/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest/findTestSplitsInclusions/report-Test5.xml
+++ b/src/test/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest/findTestSplitsInclusions/report-Test5.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="org.jenkinsci.plugins.parallel_test_executor.Test5" time="110.00" tests="20" errors="0" skipped="0" failures="0">
+  <testcase name="test5Case1" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="1.00"/>
+  <testcase name="test5Case2" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="2.00"/>
+  <testcase name="test5Case3" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="3.00"/>
+  <testcase name="test5Case4" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="4.00"/>
+  <testcase name="test5Case5" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="5.00"/>
+  <testcase name="test5Case6" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="6.00"/>
+  <testcase name="test5Case7" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="7.00"/>
+  <testcase name="test5Case8" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="8.00"/>
+  <testcase name="test5Case9" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="9.00"/>
+  <testcase name="test5Case10" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="10.00"/>
+  <testcase name="test5Case11" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="1.00"/>
+  <testcase name="test5Case12" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="2.00"/>
+  <testcase name="test5Case13" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="3.00"/>
+  <testcase name="test5Case14" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="4.00"/>
+  <testcase name="test5Case15" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="5.00"/>
+  <testcase name="test5Case16" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="6.00"/>
+  <testcase name="test5Case17" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="7.00"/>
+  <testcase name="test5Case18" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="8.00"/>
+  <testcase name="test5Case19" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="9.00"/>
+  <testcase name="test5Case20" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="10.22"/>
+</testsuite>


### PR DESCRIPTION
[JENKINS-29894](https://issues.jenkins-ci.org/browse/JENKINS-29894)

If provided, only the first bucket will use the excludesPatternFile, the other buckets will use includesPatternFile

@reviewbybees, @kohsuke especially.

- [x] Fix reviews
- [x] Address incompatibility ([comment](https://github.com/jenkinsci/parallel-test-executor-plugin/pull/14#discussion_r36798939))
- [x] Add regression test