### PR TITLE
[JENKINS-39353] new optional filter step parameter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,12 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>matrix-project</artifactId>
+      <version>1.11</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
       <version>2.3</version>

--- a/src/main/java/org/jenkinsci/plugins/parallel_test_executor/SplitStep.java
+++ b/src/main/java/org/jenkinsci/plugins/parallel_test_executor/SplitStep.java
@@ -24,6 +24,8 @@ public final class SplitStep extends AbstractStepImpl {
 
     private boolean generateInclusions;
 
+    private String filter;
+
     @DataBoundConstructor public SplitStep(Parallelism parallelism) {
         this.parallelism = parallelism;
     }
@@ -34,9 +36,16 @@ public final class SplitStep extends AbstractStepImpl {
 
     public boolean isGenerateInclusions() { return generateInclusions; }
 
+    public String getFilter() { return filter; }
+
     @DataBoundSetter
     public void setGenerateInclusions(boolean generateInclusions) {
         this.generateInclusions = generateInclusions;
+    }
+
+    @DataBoundSetter
+    public void setFilter(String filter) {
+        this.filter = filter;
     }
 
     @Extension public static final class DescriptorImpl extends AbstractStepDescriptorImpl {
@@ -65,10 +74,10 @@ public final class SplitStep extends AbstractStepImpl {
 
         @Override protected List<?> run() throws Exception {
             if (step.generateInclusions) {
-                return ParallelTestExecutor.findTestSplits(step.parallelism, build, listener, step.generateInclusions);
+                return ParallelTestExecutor.findTestSplits(step.parallelism, build, listener, step.generateInclusions, step.filter);
             } else {
                 List<List<String>> result = new ArrayList<>();
-                for (InclusionExclusionPattern pattern : ParallelTestExecutor.findTestSplits(step.parallelism, build, listener, step.generateInclusions)) {
+                for (InclusionExclusionPattern pattern : ParallelTestExecutor.findTestSplits(step.parallelism, build, listener, step.generateInclusions, step.filter)) {
                     result.add(pattern.getList());
                 }
                 return result;

--- a/src/main/resources/org/jenkinsci/plugins/parallel_test_executor/SplitStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/parallel_test_executor/SplitStep/config.jelly
@@ -7,4 +7,7 @@
     <f:entry field="generateInclusions">
         <f:checkbox title="Generate inclusion patterns"/>
     </f:entry>
+    <f:entry title="Tests filter" description="Filter pattern for test exclusions" field="filter">
+        <f:textbox />
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/parallel_test_executor/SplitStep/help-filter.html
+++ b/src/main/resources/org/jenkinsci/plugins/parallel_test_executor/SplitStep/help-filter.html
@@ -1,0 +1,1 @@
+<p>Java Pattern to apply to previous tun extracted test, so the returning sets wont include matching elements</p>


### PR DESCRIPTION
[JENKINS-39353](https://issues.jenkins-ci.org/browse/JENKINS-39353)

The matrix-project test dependency just exist to erase some ClassNotFoundErrors.

The new filter parameter (empty String by default) will exclude the matching tests from the collection stage, effectively hiding them from the split operations