### PR TITLE
[JENKINS-46028] Use primary job as fallback

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.15</version>
+    <version>2.32</version>
     <relativePath />
   </parent>
   <artifactId>parallel-test-executor</artifactId>
@@ -18,7 +18,8 @@
     </license>
   </licenses>
   <properties>
-    <jenkins.version>1.642.3</jenkins.version>
+    <jenkins.version>2.60.2</jenkins.version>
+    <java.level>8</java.level>
   </properties>
   <repositories>
     <repository>
@@ -42,7 +43,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>parameterized-trigger</artifactId>
-      <version>2.18</version>
+      <version>2.35.1</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -64,23 +65,52 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
-      <version>2.3</version>
+      <version>2.12</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>script-security</artifactId>
-      <version>1.21</version>
+      <version>1.30</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>branch-api</artifactId>
+      <version>2.0.7</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-multibranch</artifactId>
+      <version>2.15</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>structs</artifactId>
+      <version>1.9</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-api</artifactId>
+      <version>2.19</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>scm-api</artifactId>
+      <version>2.2.0</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
-      <version>2.10</version>
+      <version>2.32</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-job</artifactId>
-      <version>2.3</version>
+      <version>2.10</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -92,15 +122,64 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-basic-steps</artifactId>
-      <version>2.1</version>
+      <version>2.6</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
-      <version>2.10</version>
+      <version>2.32</version>
       <classifier>tests</classifier>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>scm-api</artifactId>
+      <version>2.2.0</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>matrix-project</artifactId>
+      <version>1.7.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>token-macro</artifactId>
+      <version>1.12.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>scm-api</artifactId>
+      <version>2.2.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>git</artifactId>
+      <version>3.5.1</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>git</artifactId>
+      <version>3.5.1</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 </project>

--- a/src/test/java/org/jenkinsci/plugins/parallel_test_executor/DontBuildBranchBuildStrategy.java
+++ b/src/test/java/org/jenkinsci/plugins/parallel_test_executor/DontBuildBranchBuildStrategy.java
@@ -1,0 +1,19 @@
+package org.jenkinsci.plugins.parallel_test_executor;
+
+import hudson.Extension;
+import jenkins.branch.BranchBuildStrategy;
+import jenkins.branch.BranchBuildStrategyDescriptor;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMSource;
+
+public class DontBuildBranchBuildStrategy extends BranchBuildStrategy {
+
+  @Override
+  public boolean isAutomaticBuild(SCMSource source, SCMHead head) {
+    // never ever build automatically
+    return false;
+  }
+
+  @Extension
+  public static class DescriptorImpl extends BranchBuildStrategyDescriptor { }
+}

--- a/src/test/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorTest.java
@@ -1,21 +1,31 @@
 package org.jenkinsci.plugins.parallel_test_executor;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import hudson.model.FreeStyleProject;
+import jenkins.branch.BranchBuildStrategy;
+import jenkins.branch.BranchSource;
+import jenkins.plugins.git.GitSCMSource;
+import jenkins.plugins.git.GitSampleRepoRule;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.cps.SnippetizerTester;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.recipes.LocalData;
 
-import static org.junit.Assert.assertTrue;
+import java.util.ArrayList;
 
 public class ParallelTestExecutorTest {
 
     @Rule
     public JenkinsRule jenkinsRule = new JenkinsRule();
+    @Rule
+    public GitSampleRepoRule sampleRepo = new GitSampleRepoRule();
 
     @Test
     @LocalData
@@ -52,4 +62,131 @@ public class ParallelTestExecutorTest {
         jenkinsRule.assertLogContains("splits[1]: includes=true list=[two.java, two.class]", b2);
     }
 
+    @Test
+    public void multiBranchFallbackToPrimaryJobForFirstBuild() throws Exception {
+        // verifies that a first time build of a project falls back to the primary branch
+
+        // - initialize a git repo
+        // - checkout the branch "primary-branch"
+        // - add new MultiBranch project "p" to Jenkins
+        // - trigger branch indexing, but don't build branches automatically
+        // - build primary-branch#1 and let it generate test results
+        // - build test-branch#1, see it using test results from primary-branch#1
+        // - build test-branch#2, see it using test results from test-branch#1
+
+        WorkflowMultiBranchProject multiBranchProject = getMultiBranchProjectForFallbackTests();
+        WorkflowJob primaryBranch = multiBranchProject.getItem("primary-branch");
+        WorkflowJob testBranch = multiBranchProject.getItem("test-branch");
+
+        // - build primary-branch#1 and let it generate test results
+        primaryBranch.setDefinition(getPipelineScriptWithTestResults());
+        build(primaryBranch);
+        assertEquals(1, primaryBranch.getLastBuild().getNumber());
+
+        // - build test-branch#1, see it using test results from primary-branch#1
+        build(testBranch);
+        WorkflowRun testbranchBuild1 = testBranch.getLastBuild();
+        assertEquals(1, testbranchBuild1.getNumber());
+        jenkinsRule.assertLogContains("Scanning primary project for test records. Starting with build p/primary-branch #1", testbranchBuild1);
+        // check that we actually pick p/primary-branch#2 because it has test results
+        jenkinsRule.assertLogContains("Using build #1 as reference", testbranchBuild1);
+
+        // - build test-branch#2, see it using test results from test-branch#1
+        build(testBranch);
+        WorkflowRun testbranchBuild2 = testBranch.getLastBuild();
+        assertEquals(2, testbranchBuild2.getNumber());
+        jenkinsRule.assertLogContains("Scanning primary project for test records. Starting with build p/primary-branch #1", testbranchBuild2);
+        // check that we actually pick p/primary-branch#2 because it has test results
+        jenkinsRule.assertLogContains("Using build #1 as reference", testbranchBuild2);
+    }
+
+    @Test
+    public void multiBranchFallbackToPrimaryJobForSecondBuild() throws Exception {
+
+        // verifies that builds of a project with a history lacking test results falls back to the primary branch
+
+        // - initialize a git repo
+        // - checkout the branch "primary-branch"
+        // - add new MultiBranch project "p" to Jenkins
+        // - trigger branch indexing, but don't build branches automatically
+        // - build test-branch#1, see it missing test results, let it generate no test results
+        // - build primary-branch#1 and let it generate test results
+        // - build primary-branch#2 and let it generate NO test results
+        // - build test-branch#2, see it using test results from primary-branch#1, let it generate no test results
+
+        WorkflowMultiBranchProject multiBranchProject = getMultiBranchProjectForFallbackTests();
+        WorkflowJob primaryBranch = multiBranchProject.getItem("primary-branch");
+        WorkflowJob testBranch = multiBranchProject.getItem("test-branch");
+
+        // - build test-branch#1, see it missing test results, let it generate no test results
+        build(testBranch);
+        WorkflowRun testbranchBuild1 = testBranch.getLastBuild();
+        assertEquals(1, testbranchBuild1.getNumber());
+        jenkinsRule.assertLogContains("No record available, so executing everything in one place", testbranchBuild1);
+
+        // - build primary-branch#1 and let it generate test results
+        primaryBranch.setDefinition(getPipelineScriptWithTestResults());
+        build(primaryBranch);
+        assertEquals(1, primaryBranch.getLastBuild().getNumber());
+
+        // - build primary-branch#2 and let it generate NO test results
+        primaryBranch.setDefinition(new CpsFlowDefinition("echo 'no test results'", true));
+        build(primaryBranch);
+        assertEquals(2, primaryBranch.getLastBuild().getNumber());
+
+        // - build test-branch#2, see it using test results from primary-branch#1, let it generate no test results
+        build(testBranch);
+        WorkflowRun testbranchBuild2 = testBranch.getLastBuild();
+        assertEquals(2, testbranchBuild2.getNumber());
+        jenkinsRule.assertLogContains("Scanning primary project for test records. Starting with build p/primary-branch #2", testbranchBuild2);
+        // check that we actually pick p/primary-branch#2 because it has test results
+        jenkinsRule.assertLogContains("Using build #1 as reference", testbranchBuild2);
+    }
+
+    private CpsFlowDefinition getPipelineScriptWithTestResults() {
+        return new CpsFlowDefinition(
+            "node {\n" +
+                "  writeFile file: 'TEST-1.xml', text: '<testsuite name=\"one\"><testcase name=\"x\"/></testsuite>'\n" +
+                "  writeFile file: 'TEST-2.xml', text: '<testsuite name=\"two\"><testcase name=\"y\"/></testsuite>'\n" +
+                "  junit 'TEST-*.xml'\n" +
+                "}", true);
+    }
+
+    private void build(WorkflowJob project) throws Exception {
+        project.scheduleBuild2(0);
+        jenkinsRule.waitUntilNoActivity();
+    }
+
+    private WorkflowMultiBranchProject getMultiBranchProjectForFallbackTests() throws Exception {
+        // create a Jenkinsfile in the master branch
+        sampleRepo.init();
+        String script =
+                "def splits = splitTests parallelism: count(2), generateInclusions: true\n" +
+                "echo \"branch=${env.BRANCH_NAME}\"\n" +
+                        "node {\n" +
+                        "  checkout scm\n" +
+                        "}";
+        sampleRepo.write("Jenkinsfile", script);
+        sampleRepo.git("add", "Jenkinsfile");
+        sampleRepo.git("commit", "--all", "--message=flow");
+        // create a new branch based on master
+        sampleRepo.git("branch", "test-branch");
+        // checkout a new branch that will get PrimaryInstanceMetadataAction because of it is checked out when indexing
+        sampleRepo.git("checkout", "-b", "primary-branch");
+
+        // create MultiBranch project "p"
+        WorkflowMultiBranchProject multiBranchProject = jenkinsRule.jenkins.createProject(WorkflowMultiBranchProject.class, "p");
+        BranchSource branchSource = new BranchSource(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", false));
+        ArrayList<BranchBuildStrategy> buildStrategies = new ArrayList<>();
+        buildStrategies.add(new DontBuildBranchBuildStrategy());
+        branchSource.setBuildStrategies(buildStrategies);
+        multiBranchProject.getSourcesList().add(branchSource);
+        // indexing will automatically trigger a run for every branch
+        multiBranchProject.scheduleBuild2(0).getFuture().get();
+        jenkinsRule.waitUntilNoActivity();
+        // MultiBranch project should have 3 items (master, test-branch, primary-branch)
+        assertEquals(3, multiBranchProject.getItems().size());
+
+        return multiBranchProject;
+    }
 }


### PR DESCRIPTION
Currently, test results are only taken from the last builds of this job. The result is that the first build(s) of a newly created branch (when using multi-branch jobs) do not run tests in parallel, unless the build for this branch is non-FAILURE. With short-lived feature branches, this results in unsatisfying long build times.

In case of multi-branch jobs, other branches could act as a source for test records as well. The question, which branch to use as reference can be answered with the SCM's help - the [`PrimaryInstanceMetadataAction`](https://github.com/jenkinsci/scm-api-plugin/blob/dfcb468a44bb29948a52ca419510f46feb580759/src/main/java/jenkins/scm/api/metadata/PrimaryInstanceMetadataAction.java#L37-L73) is assigned by several SCM plugins and denotes one/multiple branches as "primary" (in Git: the default branch when checking out).