### PR TITLE
If there was no successful build with test results, look for aborted/failed builds with test results as a fallback

### DIFF
--- a/src/test/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest/findSplitsAfterAbort/report-Test1.xml
+++ b/src/test/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest/findSplitsAfterAbort/report-Test1.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="org.jenkinsci.plugins.parallel_test_executor.Test1" time="110.00" tests="20" errors="0" skipped="0" failures="0">
+  <testcase name="test1Case1" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="1.00"/>
+  <testcase name="test1Case2" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="2.00"/>
+  <testcase name="test1Case3" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="3.00"/>
+  <testcase name="test1Case4" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="4.00"/>
+  <testcase name="test1Case5" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="5.00"/>
+  <testcase name="test1Case6" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="6.00"/>
+  <testcase name="test1Case7" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="7.00"/>
+  <testcase name="test1Case8" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="8.00"/>
+  <testcase name="test1Case9" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="9.00"/>
+  <testcase name="test1Case10" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="10.00"/>
+  <testcase name="test1Case11" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="1.00"/>
+  <testcase name="test1Case12" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="2.00"/>
+  <testcase name="test1Case13" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="3.00"/>
+  <testcase name="test1Case14" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="4.00"/>
+  <testcase name="test1Case15" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="5.00"/>
+  <testcase name="test1Case16" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="6.00"/>
+  <testcase name="test1Case17" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="7.00"/>
+  <testcase name="test1Case18" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="8.00"/>
+  <testcase name="test1Case19" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="9.00"/>
+  <testcase name="test1Case20" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="10.22"/>
+</testsuite>

--- a/src/test/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest/findSplitsAfterAbort/report-Test2.xml
+++ b/src/test/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest/findSplitsAfterAbort/report-Test2.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="org.jenkinsci.plugins.parallel_test_executor.Test2" time="110.00" tests="20" errors="0" skipped="0" failures="0">
+  <testcase name="test2Case1" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="1.00"/>
+  <testcase name="test2Case2" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="2.00"/>
+  <testcase name="test2Case3" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="3.00"/>
+  <testcase name="test2Case4" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="4.00"/>
+  <testcase name="test2Case5" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="5.00"/>
+  <testcase name="test2Case6" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="6.00"/>
+  <testcase name="test2Case7" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="7.00"/>
+  <testcase name="test2Case8" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="8.00"/>
+  <testcase name="test2Case9" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="9.00"/>
+  <testcase name="test2Case10" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="10.00"/>
+  <testcase name="test2Case11" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="1.00"/>
+  <testcase name="test2Case12" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="2.00"/>
+  <testcase name="test2Case13" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="3.00"/>
+  <testcase name="test2Case14" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="4.00"/>
+  <testcase name="test2Case15" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="5.00"/>
+  <testcase name="test2Case16" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="6.00"/>
+  <testcase name="test2Case17" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="7.00"/>
+  <testcase name="test2Case18" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="8.00"/>
+  <testcase name="test2Case19" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="9.00"/>
+  <testcase name="test2Case20" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="10.22"/>
+</testsuite>

--- a/src/test/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest/findSplitsAfterAbort/report-Test3.xml
+++ b/src/test/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest/findSplitsAfterAbort/report-Test3.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="org.jenkinsci.plugins.parallel_test_executor.Test3" time="110.00" tests="20" errors="0" skipped="0" failures="0">
+  <testcase name="test3Case1" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="1.00"/>
+  <testcase name="test3Case2" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="2.00"/>
+  <testcase name="test3Case3" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="3.00"/>
+  <testcase name="test3Case4" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="4.00"/>
+  <testcase name="test3Case5" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="5.00"/>
+  <testcase name="test3Case6" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="6.00"/>
+  <testcase name="test3Case7" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="7.00"/>
+  <testcase name="test3Case8" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="8.00"/>
+  <testcase name="test3Case9" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="9.00"/>
+  <testcase name="test3Case10" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="10.00"/>
+  <testcase name="test3Case11" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="1.00"/>
+  <testcase name="test3Case12" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="2.00"/>
+  <testcase name="test3Case13" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="3.00"/>
+  <testcase name="test3Case14" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="4.00"/>
+  <testcase name="test3Case15" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="5.00"/>
+  <testcase name="test3Case16" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="6.00"/>
+  <testcase name="test3Case17" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="7.00"/>
+  <testcase name="test3Case18" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="8.00"/>
+  <testcase name="test3Case19" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="9.00"/>
+  <testcase name="test3Case20" classname="org.jenkinsci.plugins.parallel_test_executor.Test3" time="10.22"/>
+</testsuite>

--- a/src/test/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest/findSplitsAfterAbort/report-Test4.xml
+++ b/src/test/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest/findSplitsAfterAbort/report-Test4.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="org.jenkinsci.plugins.parallel_test_executor.Test4" time="110.00" tests="20" errors="0" skipped="0" failures="0">
+  <testcase name="test4Case1" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="1.00"/>
+  <testcase name="test4Case2" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="2.00"/>
+  <testcase name="test4Case3" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="3.00"/>
+  <testcase name="test4Case4" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="4.00"/>
+  <testcase name="test4Case5" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="5.00"/>
+  <testcase name="test4Case6" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="6.00"/>
+  <testcase name="test4Case7" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="7.00"/>
+  <testcase name="test4Case8" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="8.00"/>
+  <testcase name="test4Case9" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="9.00"/>
+  <testcase name="test4Case10" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="10.00"/>
+  <testcase name="test4Case11" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="1.00"/>
+  <testcase name="test4Case12" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="2.00"/>
+  <testcase name="test4Case13" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="3.00"/>
+  <testcase name="test4Case14" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="4.00"/>
+  <testcase name="test4Case15" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="5.00"/>
+  <testcase name="test4Case16" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="6.00"/>
+  <testcase name="test4Case17" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="7.00"/>
+  <testcase name="test4Case18" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="8.00"/>
+  <testcase name="test4Case19" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="9.00"/>
+  <testcase name="test4Case20" classname="org.jenkinsci.plugins.parallel_test_executor.Test4" time="10.22"/>
+</testsuite>

--- a/src/test/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest/findSplitsAfterAbort/report-Test5.xml
+++ b/src/test/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest/findSplitsAfterAbort/report-Test5.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="org.jenkinsci.plugins.parallel_test_executor.Test5" time="110.00" tests="20" errors="0" skipped="0" failures="0">
+  <testcase name="test5Case1" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="1.00"/>
+  <testcase name="test5Case2" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="2.00"/>
+  <testcase name="test5Case3" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="3.00"/>
+  <testcase name="test5Case4" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="4.00"/>
+  <testcase name="test5Case5" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="5.00"/>
+  <testcase name="test5Case6" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="6.00"/>
+  <testcase name="test5Case7" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="7.00"/>
+  <testcase name="test5Case8" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="8.00"/>
+  <testcase name="test5Case9" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="9.00"/>
+  <testcase name="test5Case10" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="10.00"/>
+  <testcase name="test5Case11" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="1.00"/>
+  <testcase name="test5Case12" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="2.00"/>
+  <testcase name="test5Case13" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="3.00"/>
+  <testcase name="test5Case14" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="4.00"/>
+  <testcase name="test5Case15" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="5.00"/>
+  <testcase name="test5Case16" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="6.00"/>
+  <testcase name="test5Case17" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="7.00"/>
+  <testcase name="test5Case18" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="8.00"/>
+  <testcase name="test5Case19" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="9.00"/>
+  <testcase name="test5Case20" classname="org.jenkinsci.plugins.parallel_test_executor.Test5" time="10.22"/>
+</testsuite>


### PR DESCRIPTION
Amends #8 (cf. #6). I have a situation where the initial build is so slow it hits a timeout, but still managed to record most test results thanks to `realtimeJUnit` (cf. #27). I would like a subsequent build to use this partial result as a starting point.

@reviewbybees