### PR TITLE
Fix [JENKINS-50784] by using a non-lazy load of previous build execution

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutor.java
@@ -167,7 +167,7 @@ public class ParallelTestExecutor extends Builder {
             if (prevRun instanceof FlowExecutionOwner.Executable && stageName != null) {
                 FlowExecutionOwner owner = ((FlowExecutionOwner.Executable)prevRun).asFlowExecutionOwner();
                 if (owner != null) {
-                    FlowExecution execution = owner.getOrNull();
+                    FlowExecution execution = owner.get();
                     if (execution != null) {
                         DepthFirstScanner scanner = new DepthFirstScanner();
                         FlowNode stageId = scanner.findFirstMatch(execution, new StageNamePredicate(stageName));


### PR DESCRIPTION
[JENKINS-50784](https://issues.jenkins-ci.org/browse/JENKINS-50784) 