### PR TITLE
[JENKINS-53172] Make sure the reference build is not running

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,5 +119,17 @@
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>pipeline-milestone-step</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.6wind.jenkins</groupId>
+      <artifactId>lockable-resources</artifactId>
+      <version>2.3</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/src/main/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutor.java
@@ -311,7 +311,7 @@ public class ParallelTestExecutor extends Builder {
         for (int i = 0; i < NUMBER_OF_BUILDS_TO_SEARCH; i++) {// limit the search to a small number to avoid loading too much
             b = b.getPreviousBuild();
             if (b == null) break;
-            if(!RESULTS_OF_BUILDS_TO_CONSIDER.contains(b.getResult())) continue;
+            if(!RESULTS_OF_BUILDS_TO_CONSIDER.contains(b.getResult()) || b.isBuilding()) continue;
 
             AbstractTestResultAction tra = b.getAction(AbstractTestResultAction.class);
             if (tra == null) continue;

--- a/src/test/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorTest.java
@@ -1,6 +1,11 @@
 package org.jenkinsci.plugins.parallel_test_executor;
 
 import hudson.model.FreeStyleProject;
+import hudson.model.ParameterDefinition;
+import hudson.model.ParametersAction;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.StringParameterDefinition;
+import hudson.model.StringParameterValue;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.cps.SnippetizerTester;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -56,6 +61,41 @@ public class ParallelTestExecutorTest {
         jenkinsRule.assertLogContains("splits.size=2", b2);
         jenkinsRule.assertLogContains("splits[0]: includes=false list=[two.java, two.class]", b2);
         jenkinsRule.assertLogContains("splits[1]: includes=true list=[two.java, two.class]", b2);
+    }
+
+    @Test
+    @Issue("JENKINS-53172")
+    public void workflowDoesNotGenerateInclusionsFromRunningBuild() throws Exception {
+        WorkflowJob p = jenkinsRule.jenkins.createProject(WorkflowJob.class, "p");
+        ParameterDefinition sleepDef = new StringParameterDefinition("SLEEP", "100", "");
+        ParametersDefinitionProperty sleepParamsDef = new ParametersDefinitionProperty(sleepDef);
+        p.addProperty(sleepParamsDef);
+        /* We need to wait for first build to generate test result before calling splitTests in the second build, So
+        * instead of trying to use a quiet period, which is not deterministic and will introduce potential flakiness,
+        * we use the existing locking and milestone facilities in pipeline to make sure that
+        *  a) The second run waits until the first one has generated tests results by using a lock
+        *  b) Once the second build finish the previous one is killed by using milestones
+        */
+        p.setDefinition(new CpsFlowDefinition(
+                "lock('test-results') {\n" +
+                "  def splits = splitTests parallelism: count(2), generateInclusions: true\n" +
+                "  echo \"splits.size=${splits.size()}\"; for (int i = 0; i < splits.size(); i++) {\n" +
+                "    def split = splits[i]; echo \"splits[${i}]: includes=${split.includes} list=${split.list}\"\n" +
+                "  }\n" +
+                "  node {\n" +
+                "    writeFile file: 'TEST-1.xml', text: '<testsuite name=\"one\"><testcase name=\"x\" failures=\"1\"/></testsuite>'\n" +
+                "    writeFile file: 'TEST-2.xml', text: '<testsuite name=\"two\"><testcase name=\"y\"/></testsuite>'\n" +
+                "    junit 'TEST-*.xml'\n" +
+                "    currentBuild.result = 'UNSTABLE'\n" + // Needed due to https://issues.jenkins-ci.org/browse/JENKINS-48178
+                "  }\n" +
+                "}\n" +
+                "milestone 1\n" +
+                "sleep time: Integer.valueOf(params.SLEEP), unit: 'SECONDS'\n" +
+                "milestone 2", true));
+        WorkflowRun b1 = p.scheduleBuild2(0, new ParametersAction(new StringParameterValue("SLEEP", "100"))).waitForStart();
+        jenkinsRule.waitForMessage("Lock acquired on", b1);
+        WorkflowRun b2 = p.scheduleBuild2(0, new ParametersAction(new StringParameterValue("SLEEP", "0"))).get();
+        jenkinsRule.assertLogContains("splits.size=1", b2);
     }
 
     @Issue("JENKINS-27395")


### PR DESCRIPTION
[JENKINS-53172](https://issues.jenkins-ci.org/browse/JENKINS-53172)

The code to choose a previous run as reference is as follows:
```
private static TestResult findPreviousTestResult(Run<?, ?> b, TaskListener listener) {
        for (int i = 0; i < NUMBER_OF_BUILDS_TO_SEARCH; i++) {// limit the search to a small number to avoid loading too much
            b = b.getPreviousBuild();
            if (b == null) break;
            if(!RESULTS_OF_BUILDS_TO_CONSIDER.contains(b.getResult())) continue;

            AbstractTestResultAction tra = b.getAction(AbstractTestResultAction.class);
            if (tra == null) continue;

            Object o = tra.getResult();
            if (o instanceof TestResult) {
                listener.getLogger().printf("Using build #%d as reference%n", b.getNumber());
                return (TestResult) o;
            }
        }
        return null;    // couldn't find it
    }
```
Which AFAIUI does not perform any check about the running status of the potential reference run

As per javadoc `#getResult` alone is not enough guarantee that the run is finished as it can return a value even if the job has not yet finished. And I have found situations where a previous, still running run, is used as the reference. With the consequence of improper parallelization because not all tests have finished (only some of the branches).

This PR updates the aforementioned code to add a check for discarding running jobs as reference, created with the intention of get some feedback as I am still running tests on my instance.