### PR TITLE
JENKINS-53528 Do not excessively split tests

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/parallel_test_executor/CountDrivenParallelism.java
+++ b/src/main/java/org/jenkinsci/plugins/parallel_test_executor/CountDrivenParallelism.java
@@ -20,7 +20,10 @@ public class CountDrivenParallelism extends Parallelism {
 
     @Override
     public int calculate(List<TestClass> tests) {
-        return size;
+        // Don't split into 5 buckets if we only have 2 tests etc
+        return tests == null ?
+               size :
+               Math.min(size, tests.size());
     }
 
     @Symbol("count")

--- a/src/test/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest.java
+++ b/src/test/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest.java
@@ -93,6 +93,21 @@ public class ParallelTestExecutorUnitTest {
     }
 
     @Test
+    public void testWeDoNotCreateMoreSplitsThanThereAreTests() throws Exception {
+        // The test report only has 2 classes, so we should only split into 2 test executors
+        TestResult testResult = new TestResult(0L, scanner, false);
+        testResult.tally();
+        when(action.getResult()).thenReturn(testResult);
+
+        CountDrivenParallelism parallelism = new CountDrivenParallelism(5);
+        List<InclusionExclusionPattern> splits = ParallelTestExecutor.findTestSplits(parallelism, build, listener, false, null, null, false);
+        assertEquals(2, splits.size());
+        for (InclusionExclusionPattern split : splits) {
+            assertFalse(split.isIncludes());
+        }
+    }
+
+    @Test
     public void findTestSplitsInclusions() throws Exception {
         TestResult testResult = new TestResult(0L, scanner, false);
         testResult.tally();

--- a/src/test/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest/testWeDoNotCreateMoreSplitsThanThereAreTests/report-Test1.xml
+++ b/src/test/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest/testWeDoNotCreateMoreSplitsThanThereAreTests/report-Test1.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="org.jenkinsci.plugins.parallel_test_executor.Test1" time="110.00" tests="20" errors="0" skipped="0" failures="0">
+  <testcase name="test1Case1" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="1.00"/>
+  <testcase name="test1Case2" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="2.00"/>
+  <testcase name="test1Case3" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="3.00"/>
+</testsuite>


### PR DESCRIPTION
Limit the number of splits to be at most the number of test classes

@reviewbybees @jenkinsci/code-reviewers 