### PR TITLE
Replace deprecated Jenkins TimeUnit2 with Java TimeUnit

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/parallel_test_executor/TimeDrivenParallelism.java
+++ b/src/main/java/org/jenkinsci/plugins/parallel_test_executor/TimeDrivenParallelism.java
@@ -2,10 +2,11 @@ package org.jenkinsci.plugins.parallel_test_executor;
 
 import hudson.Extension;
 import hudson.model.Descriptor;
-import hudson.util.TimeUnit2;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+
 import org.jenkinsci.Symbol;
 
 /**
@@ -25,7 +26,7 @@ public class TimeDrivenParallelism extends Parallelism {
         for (TestClass test : tests) {
             total += test.duration;
         }
-        long chunk = TimeUnit2.MINUTES.toMillis(mins);
+        long chunk = TimeUnit.MINUTES.toMillis(mins);
         return (int)((total+chunk-1)/chunk);
     }
 


### PR DESCRIPTION
This is based on the analysis https://ci.jenkins.io/job/Infra/job/deprecated-usage-in-plugins/job/master/566/artifact/output/usage-by-plugin.html.

This is the relevant commit in jenkins-core https://github.com/jenkinsci/jenkins/commit/2c64d92f459174fac2283e2514e29cbb54fc7147.