### PR TITLE
Not intending to push the demo to Hub

### DIFF
--- a/demo/Makefile
+++ b/demo/Makefile
@@ -1,5 +1,4 @@
-TAG=$(shell date -I -u)
-IMAGE=jenkinsci/parallel-test-executor-demo
+IMAGE=parallel-test-executor-demo
 DOCKER_RUN=docker run --rm -p 127.0.0.1:8080:8080 -v m2repo:/m2repo -v /var/run/docker.sock:/var/run/docker.sock --group-add=$(shell stat -c %g /var/run/docker.sock) -ti
 
 validate:
@@ -17,7 +16,7 @@ copy-plugins:
 	cp -v target/test-classes/test-dependencies/*.hpi plugins
 
 build: copy-plugins
-	docker build -t $(IMAGE):$(TAG) .
+	docker build -t $(IMAGE) .
 
 # http://stackoverflow.com/q/23544282/12916 unclear how best to ensure that the jenkins user can write to this volume
 volume:
@@ -25,12 +24,4 @@ volume:
 	docker run --rm -v m2repo:/m2repo ubuntu chmod -v a+rw /m2repo
 
 run: build volume
-	$(DOCKER_RUN) $(IMAGE):$(TAG)
-
-push:
-	docker push $(IMAGE):$(TAG)
-	echo "consider also: make push-latest"
-
-push-latest: push
-	docker tag $(IMAGE):$(TAG) $(IMAGE):latest
-	docker push $(IMAGE):latest
+	$(DOCKER_RUN) $(IMAGE)

--- a/demo/README.md
+++ b/demo/README.md
@@ -2,12 +2,6 @@
 
     make run
 
-or to use the uploaded demo:
-
-    docker volume create --name=m2repo
-    sudo chmod a+rw $(docker volume inspect -f '{{.Mountpoint}}' m2repo)
-    docker run --rm -p 127.0.0.1:8080:8080 -v m2repo:/m2repo -v /var/run/docker.sock:/var/run/docker.sock --group-add=$(stat -c %g /var/run/docker.sock) -ti jenkinsci/parallel-test-executor-demo
-
 and then go to: http://localhost:8080/
 
 # Demo contents


### PR DESCRIPTION
https://hub.docker.com/repository/docker/jenkinsci/parallel-test-executor-demo has not been kept up to date and it is better to run from `make run` anyway.