### PR TITLE
[JENKINS-47206] Code cleanups related to `estimateTestsFromFiles`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(useAci: true)
+buildPlugin(useContainer: true)

--- a/src/main/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutor.java
@@ -17,8 +17,6 @@ import hudson.tasks.junit.JUnitResultArchiver;
 import hudson.tasks.test.AbstractTestResultAction;
 import hudson.tasks.test.TabulatedResult;
 import hudson.tasks.test.TestResult;
-import jenkins.security.MasterToSlaveCallable;
-import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.actions.LabelAction;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
@@ -38,6 +36,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.Functions;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -154,11 +155,11 @@ public class ParallelTestExecutor extends Builder {
         return true;
     }
 
+    private static final Pattern TEST = Pattern.compile(".+/src/test/java/(.+)[.]java");
     public static Map<String, TestClass>  findTestResultsInDirectory(Run<?,?> build, TaskListener listener, @CheckForNull FilePath workspace){
         if(workspace==null){
             return Collections.emptyMap();
         }
-        String[] tests = null;
         Map<String, TestClass> data = new TreeMap<>();
         final String baseDir = workspace.getRemote();
         String separator = null;
@@ -167,36 +168,18 @@ public class ParallelTestExecutor extends Builder {
         testFilesExpression.add("**/src/test/java/**/*Test.java");
         testFilesExpression.add("**/src/test/java/**/*Tests.java");
         testFilesExpression.add("**/src/test/java/**/*TestCase.java");
+        FilePath[] tests;
         try {
-            separator = workspace.act(new MasterToSlaveCallable<String, Throwable>() {
-
-                @Override
-                public String call() throws Throwable {
-                    return File.separator;
-                }
-            });
-            tests = workspace.act(new MasterToSlaveCallable<String[], Throwable>() {
-
-                @Override
-                public String[] call() throws Throwable {
-                    return Util.createFileSet(new File(baseDir), StringUtils.join(testFilesExpression,",")).getDirectoryScanner().getIncludedFiles();
-                }
-            });
-
+            tests = workspace.list(StringUtils.join(testFilesExpression, ","));
         } catch (Throwable throwable) {
-            throwable.printStackTrace(listener.getLogger());
+            Functions.printStackTrace(throwable, listener.getLogger());
             return data;
         }
-        if(separator.equals("\\")){
-            //for regex expression
-            separator = separator + separator;
-        }
-        for(String test : tests){
-            String path = StringUtils.join(new String[]{"src", "test", "java"}, separator);
-            test = test.split(path + separator)[1];
-            //remove suffix of file
-            test = FilenameUtils.removeExtension(test);
-            data.put(test, new TestClass(test));
+        for (FilePath test : tests) {
+            Matcher m = TEST.matcher(test.getRemote().replace('\\', '/'));
+            assert m.matches();
+            String relativePath = m.group(1); // e.g. pkg/subpkg/SomeTest
+            data.put(relativePath, new TestClass(relativePath));
         }
         return data;
 

--- a/src/main/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutor.java
@@ -161,8 +161,6 @@ public class ParallelTestExecutor extends Builder {
             return Collections.emptyMap();
         }
         Map<String, TestClass> data = new TreeMap<>();
-        final String baseDir = workspace.getRemote();
-        String separator = null;
         final List<String> testFilesExpression = new ArrayList<>();
         testFilesExpression.add("**/src/test/java/**/Test*.java");
         testFilesExpression.add("**/src/test/java/**/*Test.java");

--- a/src/test/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest.java
+++ b/src/test/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest.java
@@ -144,7 +144,7 @@ public class ParallelTestExecutorUnitTest {
         expectedTests.add("FirstTest");
         expectedTests.add("SecondTest");
 
-        expectedTests.add("somepackage" + File.separator + "ThirdTest");
+        expectedTests.add("somepackage/ThirdTest");
         expectedTests.add("ThirdTest");
         expectedTests.add("FourthTest");
         expectedTests.add("FifthTest");

--- a/src/test/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest.java
+++ b/src/test/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assume.assumeThat;
+import org.jvnet.hudson.test.Issue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -126,6 +127,7 @@ public class ParallelTestExecutorUnitTest {
         assertEquals("exclusions set should contain all elements included by inclusions set", inclusions, exclusions);
     }
 
+    @Issue("JENKINS-47206")
     @Test
     public void findTestInJavaProjectDirectory(){
         CountDrivenParallelism parallelism = new CountDrivenParallelism(5);
@@ -133,6 +135,7 @@ public class ParallelTestExecutorUnitTest {
         assertEquals(5, splits.size());
     }
 
+    @Issue("JENKINS-47206")
     @Test
     public void findTestOfJavaProjectDirectoryInWorkspace(){
         CountDrivenParallelism parallelism = new CountDrivenParallelism(5);


### PR DESCRIPTION
Assorted cleanups from #34, adding non-mock test coverage, fixing runtime warnings, API usage changes, simplifying stuff, etc.

CI does run tests on Windows. AFAICT the original code would have reported `pkg\subpkg\SomeTest` for scans from the filesystem on a Windows agent, whereas this uses `pkg/subpkg/SomeTest`, though I guess it should not matter since if you are _not_ using `estimateTestsFromFiles` _or_ this is not the initial build of the job and you actually have some test results, then https://github.com/jenkinsci/parallel-test-executor-plugin/blob/c196254eb550473ef7ad848147289f7c176a6093/src/main/java/org/jenkinsci/plugins/parallel_test_executor/TestClass.java#L45 would already been using Unix path separators and presumably tools are OK with that. We still do not have any automated end-to-end test using Maven + Surefire across multiple builds (the demo shows interactive usage on Linux).
