### PR TITLE
Demo container cannot be built cause Maven download URL is obsolete

### DIFF
--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -3,7 +3,7 @@ FROM jenkins/jenkins:2.319.3
 USER root
 
 ENV MAVEN_VERSION=3.8.4
-RUN curl -s https://dlcdn.apache.org/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz | tar xvfCz - /opt && \
+RUN curl -s https://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz | tar xvfCz - /opt && \
     ln -sv /opt/apache-maven-$MAVEN_VERSION/bin/mvn /usr/local/bin/mvn
 
 ADD repo /tmp/repo


### PR DESCRIPTION
Running `make run` fails since dlcdn.apache.org no longer contains the 3.8.4 version.

Use the archives URL instead of dlcdn.apache.org to download Maven versions.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
