### PR TITLE
[JENKINS-46028] Fix previous build resolution broken in #226

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutor.java
@@ -365,19 +365,19 @@ public class ParallelTestExecutor extends Builder {
     }
 
 
-    private static TestResult getTestResult(Job<?, ?> originProject, Run<?, ?> b, TaskListener listener) {
+    static TestResult getTestResult(Job<?, ?> originProject, Run<?, ?> b, TaskListener listener) {
         TestResult result = null;
         for (int i = 0; i < NUMBER_OF_BUILDS_TO_SEARCH; i++) {// limit the search to a small number to avoid loading too much
             if (b == null) break;
-            if (!RESULTS_OF_BUILDS_TO_CONSIDER.contains(b.getResult()) || b.isBuilding()) continue;
-
-            AbstractTestResultAction tra = b.getAction(AbstractTestResultAction.class);
-            if (tra != null) {
-                Object o = tra.getResult();
-                if (o instanceof TestResult) {
-                    listener.getLogger().printf("Using build %s as reference%n", ModelHyperlinkNote.encodeTo('/' + b.getUrl(), originProject != b.getParent() ? b.getFullDisplayName() : b.getDisplayName()));
-                    result = (TestResult) o;
-                    break;
+            if (RESULTS_OF_BUILDS_TO_CONSIDER.contains(b.getResult()) && !b.isBuilding()) {
+                AbstractTestResultAction tra = b.getAction(AbstractTestResultAction.class);
+                if (tra != null) {
+                    Object o = tra.getResult();
+                    if (o instanceof TestResult) {
+                        listener.getLogger().printf("Using build %s as reference%n", ModelHyperlinkNote.encodeTo('/' + b.getUrl(), originProject != b.getParent() ? b.getFullDisplayName() : b.getDisplayName()));
+                        result = (TestResult) o;
+                        break;
+                    }
                 }
             }
             b = b.getPreviousBuild();

--- a/src/test/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest.java
+++ b/src/test/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest.java
@@ -164,11 +164,8 @@ public class ParallelTestExecutorUnitTest {
     public void previousBuildIsOngoing() throws IOException {
         Job project = mock(Job.class);
         Run previousPreviousBuild = mock(Run.class);
-        when(previousBuild.getParent()).thenReturn(project);
         when(previousBuild.getResult()).thenReturn(null);
-        when(previousBuild.isBuilding()).thenReturn(true);
         when(previousBuild.getPreviousBuild()).thenReturn(previousPreviousBuild);
-        when(previousBuild.getAction(eq(AbstractTestResultAction.class))).thenReturn(null);
         when(previousPreviousBuild.getParent()).thenReturn(project);
         when(previousPreviousBuild.getResult()).thenReturn(Result.SUCCESS);
         when(previousPreviousBuild.getAction(eq(AbstractTestResultAction.class))).thenReturn(action);

--- a/src/test/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest/previousBuildIsOngoing/report-Test1.xml
+++ b/src/test/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest/previousBuildIsOngoing/report-Test1.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="org.jenkinsci.plugins.parallel_test_executor.Test1" time="110.00" tests="20" errors="0" skipped="0" failures="0">
+  <testcase name="test1Case1" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="1.00"/>
+  <testcase name="test1Case2" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="2.00"/>
+  <testcase name="test1Case3" classname="org.jenkinsci.plugins.parallel_test_executor.Test2" time="3.00"/>
+</testsuite>


### PR DESCRIPTION
If one of the previous build is failed or still ongoing, then the loop would iterate always on the same build until it reaches `NUMBER_OF_BUILDS_TO_SEARCH`, skipping any further builds.

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
