### PR TITLE
Do not consider a build with unloadable `TestResult`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutor.java
@@ -374,9 +374,15 @@ public class ParallelTestExecutor extends Builder {
                 if (tra != null) {
                     Object o = tra.getResult();
                     if (o instanceof TestResult) {
-                        listener.getLogger().printf("Using build %s as reference%n", ModelHyperlinkNote.encodeTo('/' + b.getUrl(), originProject != b.getParent() ? b.getFullDisplayName() : b.getDisplayName()));
-                        result = (TestResult) o;
-                        break;
+                        TestResult tr = (TestResult) o;
+                        String hyperlink = ModelHyperlinkNote.encodeTo('/' + b.getUrl(), originProject != b.getParent() ? b.getFullDisplayName() : b.getDisplayName());
+                        if (tr.getTotalCount() == 0) {
+                            listener.getLogger().printf("Build %s has no loadable test results (supposed count %d), skipping%n", tra.getTotalCount(), hyperlink);
+                        } else {
+                            listener.getLogger().printf("Using build %s as reference%n", hyperlink);
+                            result = tr;
+                            break;
+                        }
                     }
                 }
             }

--- a/src/main/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutor.java
@@ -377,7 +377,7 @@ public class ParallelTestExecutor extends Builder {
                         TestResult tr = (TestResult) o;
                         String hyperlink = ModelHyperlinkNote.encodeTo('/' + b.getUrl(), originProject != b.getParent() ? b.getFullDisplayName() : b.getDisplayName());
                         if (tr.getTotalCount() == 0) {
-                            listener.getLogger().printf("Build %s has no loadable test results (supposed count %d), skipping%n", tra.getTotalCount(), hyperlink);
+                            listener.getLogger().printf("Build %s has no loadable test results (supposed count %d), skipping%n", hyperlink, tra.getTotalCount());
                         } else {
                             listener.getLogger().printf("Using build %s as reference%n", hyperlink);
                             result = tr;


### PR DESCRIPTION
When `junitReport.xml` is malformed, https://github.com/jenkinsci/junit-plugin/blob/b4cf28bc7724c49bc93560c7bf95acdca4bbde1b/src/main/java/hudson/tasks/junit/TestResultAction.java#L227-L240 can cause `ParallelTestExecutor.getTestResult` to nonetheless consider that build a valid baseline, but with zero results which of course causes split calculation to not work sanely. Ignore such builds, and continue searching for better ones, or at worst fall back to source scanning.