### PR TITLE
Do not consider a build with unloadable `TestResult` (backport)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <version>383.${changelist}</version>
   <packaging>hpi</packaging>
   <name>Parallel Test Executor Plugin</name>
-  <url>https://github.com/jenkinsci/parallel-test-executor-plugin</url>
+  <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
   <licenses>
     <license>
       <name>MIT License</name>
@@ -20,6 +20,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <jenkins.version>2.361.4</jenkins.version>
+    <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
   <repositories>
     <repository>
@@ -34,11 +35,11 @@
       <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
-  <scm>
-    <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
-    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    <tag>HEAD</tag>
+  <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
+    <connection>scm:git:https://github.com/${gitHubRepo}</connection>
+    <developerConnection>scm:git:https://github.com/${gitHubRepo}</developerConnection>
+    <tag>${scmTag}</tag>
+    <url>https://github.com/${gitHubRepo}</url>
   </scm>
   <dependencyManagement>
     <dependencies>

--- a/src/main/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutor.java
@@ -374,9 +374,15 @@ public class ParallelTestExecutor extends Builder {
                 if (tra != null) {
                     Object o = tra.getResult();
                     if (o instanceof TestResult) {
-                        listener.getLogger().printf("Using build %s as reference%n", ModelHyperlinkNote.encodeTo('/' + b.getUrl(), originProject != b.getParent() ? b.getFullDisplayName() : b.getDisplayName()));
-                        result = (TestResult) o;
-                        break;
+                        TestResult tr = (TestResult) o;
+                        String hyperlink = ModelHyperlinkNote.encodeTo('/' + b.getUrl(), originProject != b.getParent() ? b.getFullDisplayName() : b.getDisplayName());
+                        if (tr.getTotalCount() == 0) {
+                            listener.getLogger().printf("Build %s has no loadable test results (supposed count %d), skipping%n", tra.getTotalCount(), hyperlink);
+                        } else {
+                            listener.getLogger().printf("Using build %s as reference%n", hyperlink);
+                            result = tr;
+                            break;
+                        }
                     }
                 }
             }

--- a/src/main/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutor.java
@@ -377,7 +377,7 @@ public class ParallelTestExecutor extends Builder {
                         TestResult tr = (TestResult) o;
                         String hyperlink = ModelHyperlinkNote.encodeTo('/' + b.getUrl(), originProject != b.getParent() ? b.getFullDisplayName() : b.getDisplayName());
                         if (tr.getTotalCount() == 0) {
-                            listener.getLogger().printf("Build %s has no loadable test results (supposed count %d), skipping%n", tra.getTotalCount(), hyperlink);
+                            listener.getLogger().printf("Build %s has no loadable test results (supposed count %d), skipping%n", hyperlink, tra.getTotalCount());
                         } else {
                             listener.getLogger().printf("Using build %s as reference%n", hyperlink);
                             result = tr;


### PR DESCRIPTION
#247 backported on top of https://github.com/jenkinsci/parallel-test-executor-plugin/releases/tag/383.vde60119c849a