### PR TITLE
Abort `p#1` in `ParallelTestExecutorTest.workflowDoesNotGenerateInclusionsFromRunningBuild`

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorTest.java
@@ -99,6 +99,8 @@ public class ParallelTestExecutorTest {
         jenkinsRule.waitForMessage("Lock acquired on", b1);
         WorkflowRun b2 = p.scheduleBuild2(0, new ParametersAction(new StringParameterValue("SLEEP", "0"))).get();
         jenkinsRule.assertLogContains("splits.size=1", b2);
+        b1.getExecutor().interrupt();
+        jenkinsRule.waitForCompletion(b1);
     }
 
     @Issue("JENKINS-71139")


### PR DESCRIPTION
https://github.com/jenkinsci/parallel-test-executor-plugin/pull/271/checks?check_run_id=19732555614