### PR TITLE
Parallelize per java test case

### DIFF
--- a/demo/repos/demo/Jenkinsfile
+++ b/demo/repos/demo/Jenkinsfile
@@ -20,7 +20,7 @@ stage('Sources') {
 }
 
 stage('Testing Hello') {
-  testInParallel(count(Integer.parseInt(params.SPLIT)), null, 'inclusions.txt', 'exclusions.txt', 'Testing Hello', {
+  testInParallel(count(Integer.parseInt(params.SPLIT)), javaTestCase(), 'inclusions.txt', 'exclusions.txt', 'Testing Hello', {
     unstash 'hello'
   }, {
     configFileProvider([configFile(fileId: 'jenkins-mirror', variable: 'SETTINGS')]) {
@@ -33,7 +33,7 @@ stage('Testing Hello') {
 }
 
 stage('Testing Goodbye') {
-  testInParallel(count(Integer.parseInt(params.SPLIT)), null, 'inclusions.txt', 'exclusions.txt', 'Testing Goodbye', {
+  testInParallel(count(Integer.parseInt(params.SPLIT)), javaTestCase(), 'inclusions.txt', 'exclusions.txt', 'Testing Goodbye', {
     unstash 'goodbye'
   }, {
     configFileProvider([configFile(fileId: 'jenkins-mirror', variable: 'SETTINGS')]) {

--- a/demo/repos/demo/goodbye/pom.xml
+++ b/demo/repos/demo/goodbye/pom.xml
@@ -7,8 +7,8 @@
   <version>1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <properties>
-    <maven.compiler.source>8</maven.compiler.source>
-    <maven.compiler.target>8</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
   </properties>
 
   <build>
@@ -16,7 +16,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.17</version>
+        <version>3.2.5</version>
       </plugin>
     </plugins>
   </build>

--- a/demo/repos/demo/hello/pom.xml
+++ b/demo/repos/demo/hello/pom.xml
@@ -7,8 +7,8 @@
   <version>1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <properties>
-    <maven.compiler.source>8</maven.compiler.source>
-    <maven.compiler.target>8</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
   </properties>
 
   <build>
@@ -16,7 +16,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.17</version>
+        <version>3.2.5</version>
       </plugin>
     </plugins>
   </build>

--- a/src/main/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutor.java
@@ -189,10 +189,10 @@ public class ParallelTestExecutor extends Builder {
         return true;
     }
 
-    static List<InclusionExclusionPattern> findTestSplits(Parallelism parallelism, @CheckForNull TestMode testMode, Run<?,?> build, TaskListener listener,
+    static List<InclusionExclusionPattern> findTestSplits(Parallelism parallelism, @CheckForNull TestMode inputTestMode, Run<?,?> build, TaskListener listener,
                                                           boolean generateInclusions,
                                                           @CheckForNull final String stageName, @CheckForNull FilePath workspace) throws InterruptedException {
-        testMode = testMode == null ? TestMode.getDefault() : testMode;
+        TestMode testMode = inputTestMode == null ? TestMode.getDefault() : inputTestMode;
         TestResult tr = findPreviousTestResult(build, listener);
         Map<String/*fully qualified class name*/, TestEntity> data = new TreeMap<>();
         if (tr != null) {

--- a/src/main/java/org/jenkinsci/plugins/parallel_test_executor/TestEntity.java
+++ b/src/main/java/org/jenkinsci/plugins/parallel_test_executor/TestEntity.java
@@ -10,13 +10,13 @@ import org.jenkinsci.plugins.parallel_test_executor.ParallelTestExecutor.Knapsac
 @SuppressFBWarnings(value="EQ_COMPARETO_USE_OBJECT_EQUALS", justification="Cf. justification in Knapsack.")
 public abstract class TestEntity implements Comparable<TestEntity> {
 
-    long duration;
+    protected long duration;
     /**
      * Knapsack that this test class belongs to.
      */
-    Knapsack knapsack;
+    protected Knapsack knapsack;
 
-    TestEntity() {}
+    protected TestEntity() {}
 
     public long getDuration() {
         return duration;

--- a/src/main/java/org/jenkinsci/plugins/parallel_test_executor/testmode/JavaTestCaseName.java
+++ b/src/main/java/org/jenkinsci/plugins/parallel_test_executor/testmode/JavaTestCaseName.java
@@ -30,7 +30,7 @@ public class JavaTestCaseName extends JavaClassName {
         @Override
         @NonNull
         public String getDisplayName() {
-            return "By java test cases";
+            return "By Java test cases";
         }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/parallel_test_executor/testmode/JavaTestCaseName.java
+++ b/src/main/java/org/jenkinsci/plugins/parallel_test_executor/testmode/JavaTestCaseName.java
@@ -1,0 +1,36 @@
+package org.jenkinsci.plugins.parallel_test_executor.testmode;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.model.Descriptor;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * This mode works best with java projects.
+ * <p>
+ * Parallelize per java test case.
+ * </p>
+ * <p>
+ * It is also able to estimate tests to run from the workspace content if no historical context could be found.
+ * </p>
+ */
+public class JavaTestCaseName extends JavaClassName {
+    @DataBoundConstructor
+    public JavaTestCaseName() {}
+
+    @Override
+    public boolean isSplitByCase() {
+        return true;
+    }
+
+    @Extension
+    @Symbol("javaTestCase")
+    public static class DescriptorImpl extends Descriptor<TestMode> {
+        @Override
+        @NonNull
+        public String getDisplayName() {
+            return "By java test cases";
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/parallel_test_executor/testmode/TestMode.java
+++ b/src/main/java/org/jenkinsci/plugins/parallel_test_executor/testmode/TestMode.java
@@ -45,6 +45,9 @@ public abstract class TestMode extends AbstractDescribableImpl<TestMode> impleme
     }
 
     public static TestMode fixDefault(TestMode testMode) {
+        if (testMode == null) {
+            return null;
+        }
         return JavaClassName.class.equals(testMode.getClass()) ? null : testMode;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/parallel_test_executor/testmode/TestMode.java
+++ b/src/main/java/org/jenkinsci/plugins/parallel_test_executor/testmode/TestMode.java
@@ -45,6 +45,6 @@ public abstract class TestMode extends AbstractDescribableImpl<TestMode> impleme
     }
 
     public static TestMode fixDefault(TestMode testMode) {
-        return testMode instanceof JavaClassName ? null : testMode;
+        return JavaClassName.class.equals(testMode.getClass()) ? null : testMode;
     }
 }

--- a/src/main/resources/org/jenkinsci/plugins/parallel_test_executor/testmode/JavaTestCaseName/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/parallel_test_executor/testmode/JavaTestCaseName/help.html
@@ -1,0 +1,7 @@
+<div>
+    This mode works best with java projects.
+    <p>
+    Parallelize per java test case.
+    <p>
+    It is also able to estimate tests (per class) to run from the workspace content if no historical context could be found.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/parallel_test_executor/testmode/JavaTestCaseName/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/parallel_test_executor/testmode/JavaTestCaseName/help.html
@@ -1,7 +1,7 @@
 <div>
-    This mode works best with java projects.
+    This mode works best with Java projects.
     <p>
-    Parallelize per java test case.
+    Parallelize per Java test case.
     <p>
     It is also able to estimate tests (per class) to run from the workspace content if no historical context could be found.
 </div>

--- a/src/test/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest.java
+++ b/src/test/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest.java
@@ -10,6 +10,8 @@ import hudson.tasks.test.AbstractTestResultAction;
 import java.io.IOException;
 import org.apache.tools.ant.DirectoryScanner;
 import org.hamcrest.Matchers;
+import org.jenkinsci.plugins.parallel_test_executor.testmode.JavaTestCaseName;
+import org.jenkinsci.plugins.parallel_test_executor.testmode.JavaClassName;
 import org.jenkinsci.plugins.parallel_test_executor.testmode.TestClassAndCaseName;
 import org.jenkinsci.plugins.parallel_test_executor.testmode.TestMode;
 import org.junit.Before;
@@ -86,8 +88,12 @@ public class ParallelTestExecutorUnitTest {
 
     @Test
     public void findTestSplits() throws Exception {
-        CountDrivenParallelism parallelism = new CountDrivenParallelism(5);
-        checkTestSplits(parallelism, 5, null);
+        checkTestSplits(new CountDrivenParallelism(5), 5, null);
+        checkTestSplits(new CountDrivenParallelism(5), 5, new JavaClassName());
+        // Only 5 classes
+        checkTestSplits(new CountDrivenParallelism(10), 5, new JavaClassName());
+        // Splitting by test cases we can parallelize more!
+        checkTestSplits(new CountDrivenParallelism(10), 10, new JavaTestCaseName());
     }
     
     @Test


### PR DESCRIPTION
Allows to parallelize java tests by test case.

Generates a list of exclusions/inclusions following the format expected by maven surefire plugin for `includesFile`/`excludesFile` (available since maven-surefire-plugin 3.0.0-M6), e.g. using `foo.ClassName#testMethod` format.

The initial estimate based on files still operates at class granularity, so this new mechanism kicks in on later builds.
Updated demo project accordingly.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
