### PR TITLE
Defending against corrupt builds

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutor.java
@@ -367,20 +367,24 @@ public class ParallelTestExecutor extends Builder {
         for (int i = 0; i < NUMBER_OF_BUILDS_TO_SEARCH; i++) {// limit the search to a small number to avoid loading too much
             if (b == null) break;
             if (RESULTS_OF_BUILDS_TO_CONSIDER.contains(b.getResult()) && !b.isBuilding()) {
-                AbstractTestResultAction tra = b.getAction(AbstractTestResultAction.class);
-                if (tra != null) {
-                    Object o = tra.getResult();
-                    if (o instanceof TestResult) {
-                        TestResult tr = (TestResult) o;
-                        String hyperlink = ModelHyperlinkNote.encodeTo('/' + b.getUrl(), originProject != b.getParent() ? b.getFullDisplayName() : b.getDisplayName());
-                        if (tr.getTotalCount() == 0) {
-                            listener.getLogger().printf("Build %s has no loadable test results (supposed count %d), skipping%n", hyperlink, tra.getTotalCount());
-                        } else {
-                            listener.getLogger().printf("Using build %s as reference%n", hyperlink);
-                            result = tr;
-                            break;
+                String hyperlink = ModelHyperlinkNote.encodeTo('/' + b.getUrl(), originProject != b.getParent() ? b.getFullDisplayName() : b.getDisplayName());
+                try {
+                    AbstractTestResultAction tra = b.getAction(AbstractTestResultAction.class);
+                    if (tra != null) {
+                        Object o = tra.getResult();
+                        if (o instanceof TestResult) {
+                            TestResult tr = (TestResult) o;
+                            if (tr.getTotalCount() == 0) {
+                                listener.getLogger().printf("Build %s has no loadable test results (supposed count %d), skipping%n", hyperlink, tra.getTotalCount());
+                            } else {
+                                listener.getLogger().printf("Using build %s as reference%n", hyperlink);
+                                result = tr;
+                                break;
+                            }
                         }
                     }
+                } catch (RuntimeException e) {
+                    e.printStackTrace(listener.error("Failed to load (corrupt?) build %s, skipping%n", hyperlink));
                 }
             }
             b = b.getPreviousBuild();


### PR DESCRIPTION
I've seen some builds failing during `splitTests` execution with an exception like

```
java.lang.NullPointerException: Cannot invoke "hudson.model.Run.getRootDir()" because "this.run" is null
	at hudson.tasks.junit.TestResultAction.getDataFile(TestResultAction.java:139)
	at hudson.tasks.junit.TestResultAction.load(TestResultAction.java:233)
	at hudson.tasks.junit.TestResultAction.getResult(TestResultAction.java:150)
	at hudson.tasks.junit.TestResultAction.getResult(TestResultAction.java:66)
	at org.jenkinsci.plugins.parallel_test_executor.ParallelTestExecutor.getTestResult(ParallelTestExecutor.java:372)
	at org.jenkinsci.plugins.parallel_test_executor.ParallelTestExecutor.findPreviousTestResult(ParallelTestExecutor.java:349)
	at org.jenkinsci.plugins.parallel_test_executor.ParallelTestExecutor.findTestSplits(ParallelTestExecutor.java:196)
	at org.jenkinsci.plugins.parallel_test_executor.SplitStep$Execution.run(SplitStep.java:139)
	at org.jenkinsci.plugins.parallel_test_executor.SplitStep$Execution.run(SplitStep.java:116)
	at org.jenkinsci.plugins.workflow.steps.SynchronousStepExecution.start(SynchronousStepExecution.java:37)
[...]
```

There may be a bug in the JUnit plugin, or some problem with pipeline persistence that causes it to load the build partially corrupted. In any case, the plugin should defend itself against such state and skip such build.

I don't know how to recreate such a broken run state, so no added test for now.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
