### PR TITLE
Remove help link to demo Jenkinsfile

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/parallel_test_executor/SplitStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/parallel_test_executor/SplitStep/help.html
@@ -1,4 +1,4 @@
 <div>
     Asks Jenkins to analyze the timing of tests from the last build and divide the tests for this build into roughly equal subsets for <code>parallel</code> execution.
-    <a href="https://github.com/jenkinsci/parallel-test-executor-plugin/blob/master/demo/repos/demo/Jenkinsfile" target="_blank">example <code>Jenkinsfile</code></a>
+    <a href="https://github.com/jenkinsci/parallel-test-executor-plugin/blob/c57b597b8f032d6f9b0bd2fbb03cf067b116e56f/demo/repos/demo/Jenkinsfile" target="_blank">example <code>Jenkinsfile</code></a>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/parallel_test_executor/SplitStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/parallel_test_executor/SplitStep/help.html
@@ -1,4 +1,3 @@
 <div>
     Asks Jenkins to analyze the timing of tests from the last build and divide the tests for this build into roughly equal subsets for <code>parallel</code> execution.
-    <a href="https://github.com/jenkinsci/parallel-test-executor-plugin/blob/c57b597b8f032d6f9b0bd2fbb03cf067b116e56f/demo/repos/demo/Jenkinsfile" target="_blank">example <code>Jenkinsfile</code></a>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/parallel_test_executor/SplitStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/parallel_test_executor/SplitStep/help.html
@@ -1,4 +1,4 @@
 <div>
     Asks Jenkins to analyze the timing of tests from the last build and divide the tests for this build into roughly equal subsets for <code>parallel</code> execution.
-    <a href="https://github.com/jenkinsci/parallel-test-executor-plugin/blob/master/demo/repo/Jenkinsfile" target="_blank">example <code>Jenkinsfile</code></a>
+    <a href="https://github.com/jenkinsci/parallel-test-executor-plugin/blob/master/demo/repos/demo/Jenkinsfile" target="_blank">example <code>Jenkinsfile</code></a>
 </div>


### PR DESCRIPTION
## Remove help link to demo Jenkinsfile

Reported in [documentation feedback line 1562](https://docs.google.com/spreadsheets/d/1nA8xVOkyKmZ8oTYSLdwjborT0w-BpBNNZT0nxR9deZ8/edit#gid=1087292709)

### Testing done

Confirmed that the replacement link works.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
