### PR TITLE
`NoSuchMethodError` after `junit` bump

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   </licenses>
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.387.3</jenkins.version>
+    <jenkins.version>2.462.2</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
   <repositories>
@@ -45,8 +45,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.387.x</artifactId>
-        <version>2543.vfb_1a_5fb_9496d</version>
+        <artifactId>bom-2.462.x</artifactId>
+        <version>3334.v18e2a_2f48356</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/src/test/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorTest.java
@@ -6,6 +6,7 @@ import hudson.model.ParametersAction;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.StringParameterDefinition;
 import hudson.model.StringParameterValue;
+import hudson.tasks.junit.TestResultAction;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.FileUtils;
@@ -101,6 +102,11 @@ public class ParallelTestExecutorTest {
         jenkinsRule.assertLogContains("splits.size=1", b2);
         b1.getExecutor().interrupt();
         jenkinsRule.waitForCompletion(b1);
+    }
+
+    static {
+        // https://github.com/jenkinsci/junit-plugin/pull/625#discussion_r1747346165
+        System.setProperty(TestResultAction.class.getName() + ".RESULT_CACHE_ENABLED", "false");
     }
 
     @Issue("JENKINS-71139")


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/junit-plugin/issues/644 (we hope).

https://github.com/jenkinsci/parallel-test-executor-plugin/pull/296#issuecomment-2334353751