### PR TITLE
Support Java parameterized test cases

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/parallel_test_executor/testmode/JavaParameterizedTestCaseName.java
+++ b/src/main/java/org/jenkinsci/plugins/parallel_test_executor/testmode/JavaParameterizedTestCaseName.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jenkinsci.plugins.parallel_test_executor.testmode;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.model.Descriptor;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * This mode works best with java projects.
+ * <p>
+ * Parallelize per java test case including parameters if present.
+ * </p>
+ * <p>
+ * It is also able to estimate tests to run from the workspace content if no historical context could be found.
+ * </p>
+ */
+public class JavaParameterizedTestCaseName extends JavaClassName {
+  @DataBoundConstructor
+  public JavaParameterizedTestCaseName() {
+  }
+
+  @Override 
+  public boolean isSplitByCase() {
+    return true;
+  }
+
+  @Override 
+  public boolean useParameters() {
+    return true;
+  }
+
+  @Extension
+  @Symbol("javaParamTestCase")
+  public static class DescriptorImpl extends Descriptor<TestMode> {
+    @Override
+    @NonNull
+    public String getDisplayName() {
+      return "By Java test cases with parameters";
+    }
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/parallel_test_executor/testmode/JavaTestCaseName.java
+++ b/src/main/java/org/jenkinsci/plugins/parallel_test_executor/testmode/JavaTestCaseName.java
@@ -9,7 +9,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 /**
  * This mode works best with java projects.
  * <p>
- * Parallelize per java test case.
+ * Parallelize per java test case ingoring parameters if present.
  * </p>
  * <p>
  * It is also able to estimate tests to run from the workspace content if no historical context could be found.
@@ -24,13 +24,17 @@ public class JavaTestCaseName extends JavaClassName {
         return true;
     }
 
+    @Override public boolean useParameters() {
+        return false;
+    }
+
     @Extension
     @Symbol("javaTestCase")
     public static class DescriptorImpl extends Descriptor<TestMode> {
         @Override
         @NonNull
         public String getDisplayName() {
-            return "By Java test cases";
+            return "By Java test cases without parameters";
         }
     }
 }

--- a/src/main/resources/org/jenkinsci/plugins/parallel_test_executor/testmode/JavaParameterizedTestCaseName/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/parallel_test_executor/testmode/JavaParameterizedTestCaseName/help.html
@@ -1,7 +1,7 @@
 <div>
     This mode works best with Java projects.
     <p>
-    Parallelize per Java test case ignoring parameters. If parameters are present they are considered the same test.
+    Parallelize per Java test case including parameters.
     <p>
     It is also able to estimate tests (per class) to run from the workspace content if no historical context could be found.
 </div>

--- a/src/test/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest.java
+++ b/src/test/java/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.util.stream.Collectors;
 import org.apache.tools.ant.DirectoryScanner;
 import org.hamcrest.Matchers;
+import org.jenkinsci.plugins.parallel_test_executor.testmode.JavaParameterizedTestCaseName;
 import org.jenkinsci.plugins.parallel_test_executor.testmode.JavaTestCaseName;
 import org.jenkinsci.plugins.parallel_test_executor.testmode.JavaClassName;
 import org.jenkinsci.plugins.parallel_test_executor.testmode.TestClassAndCaseName;
@@ -150,6 +151,19 @@ public class ParallelTestExecutorUnitTest {
         var allSplits = splits.stream().flatMap(s -> s.getList().stream()).collect(Collectors.toSet());
         assertThat(allSplits, hasSize(20));
         assertThat(allSplits, hasItem("org.jenkinsci.plugins.parallel_test_executor.Test1#testCase"));
+    }
+
+    @Test
+    public void findTestCasesWithParametersIncluded() throws Exception {
+        TestResult testResult = new TestResult(0L, scanner, false);
+        testResult.tally();
+        when(action.getResult()).thenReturn(testResult);
+        CountDrivenParallelism parallelism = new CountDrivenParallelism(3);
+        List<InclusionExclusionPattern> splits = Splitter.findTestSplits(parallelism, new JavaParameterizedTestCaseName(), build, listener, false, null, null);
+        assertEquals(3, splits.size());
+        var allSplits = splits.stream().flatMap(s -> s.getList().stream()).collect(Collectors.toSet());
+        assertThat(allSplits, hasSize(22));
+        assertThat(allSplits, hasItem("org.jenkinsci.plugins.parallel_test_executor.Test1#testCase[param1]"));
     }
 
     @Test

--- a/src/test/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest/findTestCasesWithParametersIncluded/report-Test1.xml
+++ b/src/test/resources/org/jenkinsci/plugins/parallel_test_executor/ParallelTestExecutorUnitTest/findTestCasesWithParametersIncluded/report-Test1.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="org.jenkinsci.plugins.parallel_test_executor.Test1" time="112.22" tests="21" errors="0" skipped="0" failures="0">
+  <testcase name="testCase[param1]" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="1.00"/>
+  <testcase name="testCase[param2]" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="1.00"/>
+  <testcase name="testCase[param3]" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="1.00"/>
+  <testcase name="test1Case2" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="2.00"/>
+  <testcase name="test1Case3" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="3.00"/>
+  <testcase name="test1Case4" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="4.00"/>
+  <testcase name="test1Case5" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="5.00"/>
+  <testcase name="test1Case6" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="6.00"/>
+  <testcase name="test1Case7" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="7.00"/>
+  <testcase name="test1Case8" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="8.00"/>
+  <testcase name="test1Case9" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="9.00"/>
+  <testcase name="test1Case10" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="10.00"/>
+  <testcase name="test1Case11" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="1.00"/>
+  <testcase name="test1Case12" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="2.00"/>
+  <testcase name="test1Case13" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="3.00"/>
+  <testcase name="test1Case14" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="4.00"/>
+  <testcase name="test1Case15" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="5.00"/>
+  <testcase name="test1Case16" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="6.00"/>
+  <testcase name="test1Case17" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="7.00"/>
+  <testcase name="test1Case18" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="8.00"/>
+  <testcase name="test1Case19" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="9.00"/>
+  <testcase name="test1Case20" classname="org.jenkinsci.plugins.parallel_test_executor.Test1" time="10.22"/>
+</testsuite>


### PR DESCRIPTION
Add new testmode, ie., `javaParamTestCase` that allows to split and run in parallel Java parameterized tests. The JavaTestCaseName mode is retained for backwards compatibility reasons.

From maven-surefire-plugin:3.0.0-M6 onwards method filtering (thus parameters) are supported in includesFile and excludesFile. Some basic examples of using Surefire with parameterized tests can be found in https://github.com/zabetak/surefire-parameterized-tests

Relates to: #279, #283

### Testing done

New unit test added.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue